### PR TITLE
Script-based identification & sense-check diagnostics (beyond the notebooks)

### DIFF
--- a/validation/diagnostics/README.md
+++ b/validation/diagnostics/README.md
@@ -1,0 +1,90 @@
+# Identification diagnostics
+
+Scripts that reproduce the **identification** findings of
+`validation/Continous_Frugal_Flows.ipynb` — *does the frugal flow recover the
+causal-margin parameters it was trained to identify?* — as runnable, sense-checkable
+scripts instead of notebook cells.
+
+**This folder is purely additive.** Every script only *imports and calls* existing
+code in `frugal_flows/` and `validation/`. Nothing in the core package or the
+existing `validation/*.py` modules is modified — `git diff` outside this folder is
+empty.
+
+## Environment
+
+Everything runs in the one working env (see project memory `project-working-env`):
+
+```bash
+micromamba run -n frugal-flows-flowjax python -m diagnostics.<script> [flags]
+```
+
+Run from the `validation/` directory (so the `diagnostics` package and the existing
+`data_processing_and_simulations` package are both importable). Ground-truth data
+comes from the R `causl` package via rpy2 — already installed in that env.
+
+## The three diagnostics
+
+| Script | Question | Output (`outputs/`) |
+|---|---|---|
+| `d1_ate_recovery.py` | **Does it identify `(ate, const, scale)`?** Fit over N seeds, extract the learned causal margin, compare to truth. | `d1_<gen>_recovery.csv`, bias table (printed), `d1_<gen>_recovery.pdf` (boxplot vs truth) |
+| `d2_margin_shape.py` | **What does the causal margin look like?** Interventional outcome quantile functions / densities for `do(X=0)` vs `do(X=1)`; the gap is the ATE. | `d2_<gen>_margin.pdf`, sense-checks (printed) |
+| `d3_moment_match.py` | **Are the treatment/covariate moments what causl intended?** Per-variable mean/var vs a causl ground-truth reference. | `d3_<gen>_moments.csv`, table (printed), `d3_<gen>_moments.pdf` (histograms) |
+
+Run them individually, or all three with one config:
+
+```bash
+# fast feedback (small n, few seeds, short training) — sanity check the pipeline
+micromamba run -n frugal-flows-flowjax python -m diagnostics.run_diagnostics --smoke
+
+# notebook-scale identification run on the mixed (Gaussian+Gamma) generator
+micromamba run -n frugal-flows-flowjax python -m diagnostics.run_diagnostics \
+    --generator mixed --const 1 --ate 1 --n-samples 20000 --n-iter 25
+```
+
+Key flags (shared): `--generator {gaussian,mixed,discrete,many_discrete}`,
+`--const` / `--ate` (the generator's `causal_params = [const, ate]`),
+`--n-samples`, `--seed`, `--smoke`. `d1`/`run` also take `--n-iter`; `d3`/`run`
+take `--ref-n` (causl reference size).
+
+## How the truth is defined
+
+The causl generators encode the ground truth as **`causal_params = [const, ate]`**:
+the outcome formula is `Y ~ X` with linear predictor `const + ate * X` and a Gaussian
+family at `phi = 1`, so the causal-margin truth is `{ate, const, scale=1}`.
+`_harness.true_params_from_causal_params` derives this.
+
+> The notebook sets `TRUE_PARAMS = {ate:1, const:0, scale:1}` while generating with
+> `CAUSAL_PARAMS = [2, 5]` — an internal inconsistency. These scripts derive the truth
+> from `causal_params` so the comparison is always correct.
+
+## causl conventions used by d3
+
+d3's ground truth comes from causl itself. Primary route: a large `causalSamp` draw
+(Monte-Carlo population reference) — works for every variable including the treatment
+`X`, which is binomial *conditional* on `Z` and has no closed-form marginal. For
+intercept-only covariates the closed forms cross-check it (verified — see project
+memory `reference-causl-conventions`):
+
+| causl family | code | link | mean | variance |
+|---|---|---|---|---|
+| Gamma | 3 | log | `exp(beta)` | `phi * exp(beta)^2` |
+| binomial | 0/5 | logit | `expit(beta)` | `p(1-p)` |
+| gaussian | 1 | identity | `beta` | `phi` |
+
+(e.g. the `mixed` generator's `Zc~1, beta=1, phi=1` Gammas have true mean `e=2.718`,
+var `7.389` — which the causl reference reproduces.)
+
+## Design notes
+
+- **The shared step is `_harness.fit_once`**, a thin wrapper over the existing
+  `causl_sim_data_generation.frugal_fitting`. It returns the recovered params (d1),
+  the fitted margin object + flow (d2), and the input data (d3).
+- We deliberately bypass the notebook's `run_simulations` (it hardcodes
+  `causal_model='gaussian'`, prints intermediate state, and self-references
+  `causl_py.`) and loop `frugal_fitting` directly — same finding, plus we keep the
+  fitted-flow object d2/d3 need. This is a *choice not to call* that function, not a
+  modification of it.
+- **d3 mode 2 (deferred):** compare causl truth against the *model's reconstruction*
+  of X/Z (does the flow distort the covariates?). That needs the `FrugalFlowModel`
+  sampler and will be added as a second mode — still without touching core code.
+- `outputs/` holds regenerated artefacts (CSVs + PDFs); safe to delete.

--- a/validation/diagnostics/__init__.py
+++ b/validation/diagnostics/__init__.py
@@ -1,0 +1,15 @@
+"""Identification diagnostics for Frugal Flows (scripts, not notebooks).
+
+This package reproduces the *identification* findings of
+``validation/Continous_Frugal_Flows.ipynb`` as runnable, sense-checkable
+scripts. It is purely additive: it only imports and calls existing code in
+``frugal_flows/`` and ``validation/`` — it never modifies it.
+
+Run everything inside the one working env:
+
+    micromamba run -n frugal-flows-flowjax python -m validation.diagnostics.d1_ate_recovery --help
+
+(or ``cd validation && python -m diagnostics.d1_ate_recovery`` — see ``_harness``
+for the path handling that makes the existing ``data_processing_and_simulations``
+package importable from here.)
+"""

--- a/validation/diagnostics/_harness.py
+++ b/validation/diagnostics/_harness.py
@@ -1,0 +1,199 @@
+"""Shared, script-local plumbing for the identification diagnostics.
+
+NOTHING here re-implements modelling logic. It is a thin wrapper around the
+*existing* ``validation/data_processing_and_simulations/causl_sim_data_generation.py``
+(generators + ``frugal_fitting``). The only reason this file exists is to give
+the three diagnostic scripts a single, well-documented entry point and to make
+the truth/parametrisation explicit (the notebook leaves it implicit and even
+self-inconsistent — see ``true_params_from_causal_params``).
+
+Key facts this harness encodes (verified against the source, 2026-06-10):
+
+* The causl generators encode the ground truth as ``causal_params = [const, ate]``:
+  the outcome formula is ``Y ~ X`` with linear predictor ``const + ate * X`` and a
+  Gaussian family at ``phi = 1`` (so the causal margin's ``scale`` truth is 1.0).
+* ``frugal_fitting`` already extracts the trained causal margin
+  (``UnivariateNormalCDF``) for us as ``out['causal_margin']`` — we do NOT need to
+  re-derive the brittle ``flow.bijection.bijections[-1].bijection.bijections[0]``
+  index path.
+* For ``causal_model='gaussian'`` the ``causal_model_args`` are *initial* values
+  for the margin's ``(ate, const, scale)`` — the fit then moves them to recover
+  the truth.
+
+NB: the notebook's ``run_simulations`` hardcodes ``causal_model='gaussian'``,
+prints intermediate results, and self-references ``causl_py.frugal_fitting``. We
+deliberately bypass it and loop ``frugal_fitting`` ourselves — same finding, but
+we also keep the fitted flow object that diagnostics d2/d3 need. (Not a fix to
+the core code; we simply don't call that function.)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass, field
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+# --- make the existing validation package importable from validation/diagnostics/ ---
+# validation/diagnostics/_harness.py -> parent of parent is validation/
+_VALIDATION_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _VALIDATION_DIR not in sys.path:
+    sys.path.insert(0, _VALIDATION_DIR)
+
+# Importing this module triggers `importr('causl')` at load time (the try/except
+# at the top of the module). That requires the frugal-flows-flowjax env.
+import data_processing_and_simulations.causl_sim_data_generation as causl_py  # noqa: E402
+
+# The spline-based causal margin is numerically delicate; the package assumes x64
+# (benchmarking.py sets this globally). Mirror it here so a standalone script run
+# behaves identically to the notebook.
+jax.config.update("jax_enable_x64", True)
+
+
+# Hyperparameters copied verbatim from Continous_Frugal_Flows.ipynb so the
+# scripts reproduce the notebook fit. `show_progress` is added (flows straight
+# through frugal_fitting -> train_frugal_flow) so loops can be quiet.
+DEFAULT_HYPERPARAMS: dict = {
+    "learning_rate": 5e-3,
+    "RQS_knots": 8,
+    "flow_layers": 5,
+    "nn_width": 50,
+    "nn_depth": 4,
+    "max_patience": 100,
+    "max_epochs": 10000,
+    "show_progress": False,
+}
+
+# A deliberately small/fast config for the feedback loop (NOT the notebook scale).
+SMOKE_HYPERPARAMS: dict = {
+    **DEFAULT_HYPERPARAMS,
+    "max_patience": 20,
+    "max_epochs": 400,
+}
+
+# The causl ground-truth generators, by short name. These are the same callables
+# the notebook uses; we only give them friendly handles.
+GENERATORS: dict = {
+    "gaussian": causl_py.generate_gaussian_samples,
+    "mixed": causl_py.generate_mixed_samples,
+    "discrete": causl_py.generate_discrete_samples,
+    "many_discrete": causl_py.generate_many_discrete_samples,
+}
+
+PARAM_NAMES = ("ate", "const", "scale")
+
+
+def true_params_from_causal_params(causal_params) -> dict:
+    """Map a generator's ``causal_params = [const, ate]`` to the causal-margin truth.
+
+    Returns ``{'ate', 'const', 'scale'}``. ``scale`` is 1.0 because the causl
+    outcome family is Gaussian with ``phi = 1``.
+
+    This is the correct truth to compare recovered params against. (The notebook
+    sets ``TRUE_PARAMS = {ate:1, const:0, scale:1}`` while generating with
+    ``CAUSAL_PARAMS = [2, 5]`` — an internal inconsistency we avoid by deriving
+    the truth here.)
+    """
+    const, ate = float(causal_params[0]), float(causal_params[1])
+    return {"ate": ate, "const": const, "scale": 1.0}
+
+
+def _scalar(x) -> float:
+    """Coerce a size-1 jax/np array (or python scalar) to a float."""
+    return float(np.ravel(np.asarray(x))[0])
+
+
+@dataclass
+class FitResult:
+    """One frugal-flow fit on one ground-truth dataset.
+
+    Holds enough for all three diagnostics: the recovered margin params (d1), the
+    fitted margin object + flow (d2), and the input data arrays (d3).
+    """
+
+    seed: int
+    recovered: dict           # {'ate', 'const', 'scale'} learned by the margin
+    true_params: dict         # {'ate', 'const', 'scale'} from the generator
+    causal_margin: object     # UnivariateNormalCDF
+    frugal_flow: object
+    val_loss: float
+    data: dict = field(repr=False, default_factory=dict)  # {'X','Y','Z_cont','Z_disc'}
+
+
+def generate_dataset(generator_name: str, causal_params, n_samples: int, seed: int) -> dict:
+    """Draw one ground-truth dataset from a named causl generator.
+
+    Returns ``{'Z_disc', 'Z_cont', 'X', 'Y'}`` (the generators' native dict).
+    """
+    gen = GENERATORS[generator_name]
+    return gen(n_samples, causal_params=causal_params, seed=seed)
+
+
+def fit_once(
+    generator_name: str = "mixed",
+    causal_params=(1.0, 1.0),
+    n_samples: int = 2000,
+    seed: int = 0,
+    hyperparams: dict | None = None,
+    causal_model: str = "gaussian",
+    init_args: dict | None = None,
+) -> FitResult:
+    """Generate one dataset and fit one frugal flow; return recovered params + flow.
+
+    This is the single shared step under all three diagnostics. It calls the
+    existing ``causl_py.frugal_fitting`` unchanged.
+
+    Args:
+        generator_name: key into ``GENERATORS`` (e.g. ``'mixed'``).
+        causal_params: ``[const, ate]`` passed to the generator.
+        n_samples: dataset size.
+        seed: seed for both data generation and the fit.
+        hyperparams: frugal-flow hyperparameters; defaults to ``DEFAULT_HYPERPARAMS``.
+        causal_model: causal-margin parametrisation (``'gaussian'`` here).
+        init_args: initial ``causal_model_args`` for the margin. Defaults to the
+            notebook's ``{'ate': [0.], 'const': 0., 'scale': 1.}``.
+    """
+    hyperparams = dict(DEFAULT_HYPERPARAMS if hyperparams is None else hyperparams)
+    if init_args is None:
+        init_args = {"ate": jnp.array([0.0]), "const": 0.0, "scale": 1.0}
+
+    data = generate_dataset(generator_name, causal_params, n_samples, seed)
+    Z_disc, Z_cont, X, Y = data["Z_disc"], data["Z_cont"], data["X"], data["Y"]
+
+    out, min_loss = causl_py.frugal_fitting(
+        X,
+        Y,
+        Z_cont=Z_cont,
+        Z_disc=Z_disc,
+        seed=seed,
+        frugal_flow_hyperparams=hyperparams,
+        causal_model=causal_model,
+        causal_model_args=init_args,
+    )
+
+    margin = out["causal_margin"]  # UnivariateNormalCDF, already extracted upstream
+    recovered = {
+        "ate": _scalar(margin.ate),
+        "const": _scalar(margin.const),
+        "scale": _scalar(margin.scale),
+    }
+
+    return FitResult(
+        seed=seed,
+        recovered=recovered,
+        true_params=true_params_from_causal_params(causal_params),
+        causal_margin=margin,
+        frugal_flow=out["frugal_flow"],
+        val_loss=float(min_loss),
+        data={"X": X, "Y": Y, "Z_cont": Z_cont, "Z_disc": Z_disc},
+    )
+
+
+def outputs_dir() -> str:
+    """Absolute path to ``validation/diagnostics/outputs`` (created if missing)."""
+    d = os.path.join(os.path.dirname(os.path.abspath(__file__)), "outputs")
+    os.makedirs(d, exist_ok=True)
+    return d

--- a/validation/diagnostics/ate_extraction_suite.py
+++ b/validation/diagnostics/ate_extraction_suite.py
@@ -1,0 +1,323 @@
+"""Can the frugal flow extract the ATE across continuous OUTCOME families?
+
+A no-notebook, fast, script-based generalisation of the notebook's identification
+check. For each outcome family (Gaussian, Gamma, ...) and each causal-margin arm
+(`gaussian` location-shift vs `flexible_continuous` treatment-conditioned spline)
+it:
+
+  1. generates a causl ground-truth dataset (known true ATE, per the family's link);
+  2. fits the frugal flow;
+  3. extracts the ATE MODEL-AGNOSTICALLY via paired common-random-numbers MC
+     (sample the full fitted flow at fixed T, read dim 0 = Y) — works for every
+     causal_model, unlike the gaussian-only `.ate` field;
+  4. runs numerical pass/fail checks ("test sticks"): runs-clean, ATE recovery,
+     interventional-mean match;
+  5. renders two PNG figures (interventional-margin grid + ATE scorecard) sized
+     for viewing on a phone.
+
+Two tiers, like quick_sense_check.py:
+  SMOKE (default, n=2000): runs-clean is HARD-gated; ATE/mean are informational.
+  FULL  (--full, n=20000):  ATE/mean recovery additionally HARD-gated.
+
+Usage (from validation/, in the frugal-flows-flowjax env):
+  micromamba run -n frugal-flows-flowjax python -m diagnostics.ate_extraction_suite
+  micromamba run -n frugal-flows-flowjax python -m diagnostics.ate_extraction_suite \
+      --families gaussian,gamma --arms gaussian,flexible_continuous --full
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import jax
+
+jax.config.update("jax_enable_x64", True)  # must precede any jnp array creation
+
+import jax.numpy as jnp  # noqa: E402
+import jax.random as jr  # noqa: E402
+import numpy as np  # noqa: E402
+
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg")  # headless: write PNGs, no display
+import matplotlib.pyplot as plt  # noqa: E402
+
+_VALIDATION_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _VALIDATION_DIR not in sys.path:
+    sys.path.insert(0, _VALIDATION_DIR)
+
+import data_processing_and_simulations.causl_sim_data_generation as causl_py  # noqa: E402
+from diagnostics.outcome_families import FAMILIES  # noqa: E402
+from diagnostics.quick_sense_check import (  # noqa: E402
+    base_hyperparams,
+    fit_model,
+    model_args,  # noqa: F401  (kept for parity / external reuse)
+)
+
+ARM_LABEL = {
+    "gaussian": "additive shift",
+    "flexible_continuous": "spline",
+    "location_translation": "loc-translation",
+}
+
+
+def intervene(key, ff, cond_dim, n_mc):
+    """Paired-CRN interventional readout. Returns the do(0)/do(1) Y samples + summaries.
+
+    Same base draw (same `key`) pushed through T=0 and T=1, so tau(u)=Q_1(u)-Q_0(u)
+    is paired. ATE = mean(tau); tau_sd = std(tau) = effect heterogeneity across
+    quantiles (~0 for a pure location shift, >0 for a genuine spline effect).
+    """
+    y0 = np.asarray(ff.sample(key, condition=jnp.zeros((n_mc, cond_dim)))[:, 0])
+    y1 = np.asarray(ff.sample(key, condition=jnp.ones((n_mc, cond_dim)))[:, 0])
+    tau = y1 - y0
+    return {
+        "y0": y0, "y1": y1,
+        "mean0": float(np.mean(y0)), "mean1": float(np.mean(y1)),
+        "var0": float(np.var(y0)), "var1": float(np.var(y1)),
+        "ate": float(np.mean(tau)), "tau_sd": float(np.std(tau)),
+        "frac_neg": float(np.mean(np.concatenate([y0, y1]) <= 0)),
+        "anynan": bool(np.any(np.isnan(y0)) or np.any(np.isnan(y1))),
+    }
+
+
+TAU_CURVE_BINS = 40  # fixed => identical u-grid across seeds (stackable curves)
+
+
+def tau_curve(y0, y1, n_bins=TAU_CURVE_BINS):
+    """Quantile-resolved paired effect tau(u) = Q_1(u) - Q_0(u) on a fixed u-grid.
+
+    Pairs are aligned by base draw (same key in `intervene`), so tau[i]=y1[i]-y0[i]
+    is the effect at draw i's latent quantile. The causal margin is monotone, so
+    ranking by the control outcome y0 recovers that quantile; binning tau by y0-rank
+    then gives tau as a function of u in (0,1). A FIXED n_bins yields an identical
+    u-grid across seeds, so per-seed curves stack directly for a bias (seed-mean)
+    vs variance (seed-SD) decomposition.
+
+    For a pure location shift the truth is flat at the ATE; any slope/curvature the
+    spline shows on such a DGP is spurious. Returns (u_centers[n_bins], tau_of_u[n_bins]).
+    """
+    y0 = np.asarray(y0); y1 = np.asarray(y1)
+    tau = (y1 - y0)[np.argsort(np.asarray(y0), kind="stable")]
+    n = len(tau)
+    edges = np.linspace(0, n, n_bins + 1).astype(int)
+    tau_of_u = np.array([tau[a:b].mean() if b > a else np.nan
+                         for a, b in zip(edges[:-1], edges[1:])])
+    u_centers = (np.arange(n_bins) + 0.5) / n_bins
+    return u_centers, tau_of_u
+
+
+def run_cell(key, fam, arm, Y, u_z, X, args):
+    """Fit one (family, arm) and score it. Returns a result dict (+ samples for plots)."""
+    cp = [args.const, args.ate]
+    true_ate = fam.true_ate(cp)
+    true_m0, true_m1 = fam.mean_do(cp, 0), fam.mean_do(cp, 1)
+
+    try:
+        ff, val_loss = fit_model(jr.fold_in(key, 1), Y, u_z, X, arm, args.epochs)
+        m = intervene(jr.fold_in(key, 2), ff, X.shape[1], args.n_mc)
+        crashed = None
+    except Exception as e:  # keep the suite running; report the failure in the row
+        return {
+            "family": fam.name, "arm": arm, "crashed": repr(e),
+            "true_ate": true_ate, "ate": float("nan"), "ate_relerr": float("nan"),
+            "tau_sd": float("nan"), "mean0": float("nan"), "mean1": float("nan"),
+            "true_m0": true_m0, "true_m1": true_m1, "frac_neg": float("nan"),
+            "t_runs": False, "t_ate": False, "t_mean": False, "pass": False,
+            "y0": None, "y1": None,
+        }
+
+    ate = m["ate"]
+    ate_relerr = abs(ate - true_ate) / max(abs(true_ate), 1e-8)
+    mean_err = max(abs(m["mean0"] - true_m0), abs(m["mean1"] - true_m1))
+
+    t_runs = bool(np.isfinite(val_loss)) and (not m["anynan"]) and m["var0"] > 0 and m["var1"] > 0
+    t_ate = ate_relerr < args.tol
+    t_mean = mean_err < args.mean_tol
+    passed = (t_runs and t_ate and t_mean) if args.full else t_runs
+
+    return {
+        "family": fam.name, "arm": arm, "crashed": crashed,
+        "val_loss": val_loss, "true_ate": true_ate, "ate": ate, "ate_relerr": ate_relerr,
+        "tau_sd": m["tau_sd"], "mean0": m["mean0"], "mean1": m["mean1"],
+        "true_m0": true_m0, "true_m1": true_m1, "var0": m["var0"], "var1": m["var1"],
+        "frac_neg": m["frac_neg"], "mean_err": mean_err,
+        "t_runs": t_runs, "t_ate": t_ate, "t_mean": t_mean, "pass": passed,
+        "y0": m["y0"], "y1": m["y1"],
+    }
+
+
+# ----------------------------------------------------------------------------- figures
+def fig_margins(rows, families, arms, cp, outpath, seed):
+    """Grid: rows = outcome families, cols = arms. Each cell overlays the model's
+    interventional Y|do(0)/Y|do(1) on the analytic ground-truth shape (dashed)."""
+    rng = np.random.default_rng(seed)
+    nf, na = len(families), len(arms)
+    fig, axes = plt.subplots(nf, na, figsize=(5.2 * na, 4.0 * nf), squeeze=False)
+    by = {(r["family"], r["arm"]): r for r in rows}
+
+    for i, fname in enumerate(families):
+        fam = FAMILIES[fname]
+        # shared bins per family row (truth do(0)+do(1)) so cells are comparable
+        t0 = fam.sample_truth(cp, 0, 40000, rng)
+        t1 = fam.sample_truth(cp, 1, 40000, rng)
+        lo, hi = np.percentile(np.concatenate([t0, t1]), [0.5, 99.5])
+        bins = np.linspace(lo, hi, 60)
+        for j, arm in enumerate(arms):
+            ax = axes[i][j]
+            r = by.get((fname, arm))
+            # truth outlines
+            ax.hist(t0, bins=bins, density=True, histtype="step", color="C0", ls="--", lw=1.6, label="truth do(0)")
+            ax.hist(t1, bins=bins, density=True, histtype="step", color="C1", ls="--", lw=1.6, label="truth do(1)")
+            if r is not None and r["y0"] is not None:
+                ax.hist(r["y0"], bins=bins, density=True, alpha=0.45, color="C0", label="model do(0)")
+                ax.hist(r["y1"], bins=bins, density=True, alpha=0.45, color="C1", label="model do(1)")
+                title = (f"{fname} / {ARM_LABEL.get(arm, arm)}\n"
+                         f"ATE {r['ate']:+.2f} (true {r['true_ate']:+.2f}, "
+                         f"err {r['ate_relerr']:.0%})")
+            else:
+                title = f"{fname} / {ARM_LABEL.get(arm, arm)}\n(crashed)"
+            ax.set_title(title, fontsize=12)
+            ax.set_xlim(lo, hi)
+            ax.tick_params(labelsize=9)
+            if i == 0 and j == 0:
+                ax.legend(fontsize=8, framealpha=0.9)
+    fig.suptitle("Interventional outcome margins: model vs causl truth", fontsize=15, y=0.997)
+    fig.tight_layout(rect=[0, 0, 1, 0.985])
+    fig.savefig(outpath, dpi=120)
+    plt.close(fig)
+
+
+def fig_scorecard(rows, families, arms, outpath):
+    """ATE recovery at a glance: true ATE (black bar) vs each arm's estimate (dots)."""
+    fig, ax = plt.subplots(figsize=(max(6, 2.2 * len(families)), 5.2))
+    by = {(r["family"], r["arm"]): r for r in rows}
+    x = np.arange(len(families))
+    width = 0.6
+    # draw true ATE as a wide black tick per family
+    for i, fname in enumerate(families):
+        r_any = next((by[(fname, a)] for a in arms if (fname, a) in by), None)
+        if r_any is None:
+            continue
+        ta = r_any["true_ate"]
+        ax.hlines(ta, i - width / 2, i + width / 2, color="black", lw=3, zorder=3,
+                  label="true ATE" if i == 0 else None)
+        ax.annotate(f"{ta:+.2f}", (i, ta), textcoords="offset points", xytext=(0, 8),
+                    ha="center", fontsize=10, fontweight="bold")
+    # arm estimates
+    colors = {"gaussian": "#d62728", "flexible_continuous": "#1f77b4", "location_translation": "#2ca02c"}
+    offs = np.linspace(-0.18, 0.18, len(arms))
+    for k, arm in enumerate(arms):
+        xs, ys = [], []
+        for i, fname in enumerate(families):
+            r = by.get((fname, arm))
+            if r is None or not np.isfinite(r["ate"]):
+                continue
+            xs.append(i + offs[k]); ys.append(r["ate"])
+            ax.annotate(f"{r['ate_relerr']:.0%}", (i + offs[k], r["ate"]),
+                        textcoords="offset points", xytext=(0, -14), ha="center", fontsize=8,
+                        color=colors.get(arm, "gray"))
+        ax.scatter(xs, ys, s=130, color=colors.get(arm, "gray"), zorder=4,
+                   label=f"{ARM_LABEL.get(arm, arm)} est", edgecolor="white", linewidth=1.2)
+    ax.set_xticks(x); ax.set_xticklabels(families, fontsize=12)
+    ax.set_ylabel("ATE = E[Y|do(1)] - E[Y|do(0)]", fontsize=12)
+    ax.set_title("ATE recovery by outcome family and causal-margin arm\n"
+                 "(% = relative error vs truth)", fontsize=13)
+    ax.grid(axis="y", alpha=0.3)
+    ax.legend(fontsize=10, loc="best")
+    fig.tight_layout()
+    fig.savefig(outpath, dpi=120)
+    plt.close(fig)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--families", default="gaussian,gamma", help="comma-separated outcome families")
+    p.add_argument("--arms", default="gaussian,flexible_continuous", help="comma-separated causal_model arms")
+    p.add_argument("--full", action="store_true", help="recovery tier: large n + HARD ATE/mean gating")
+    p.add_argument("--n", type=int, default=None, help="train n (default 2000 smoke / 20000 full)")
+    p.add_argument("--epochs", type=int, default=None, help="max epochs (default 400 smoke / 1500 full)")
+    p.add_argument("--n-mc", type=int, default=20000)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--const", type=float, default=0.0, help="causal_params[0] (log-mean for gamma)")
+    p.add_argument("--ate", type=float, default=1.0, help="causal_params[1] (log-scale effect for gamma)")
+    p.add_argument("--tol", type=float, default=0.15, help="relative ATE tol (full tier)")
+    p.add_argument("--mean-tol", type=float, default=0.4, help="abs interventional-mean tol (full tier)")
+    p.add_argument("--outdir", default=None)
+    args = p.parse_args()
+
+    if args.n is None:
+        args.n = 20000 if args.full else 2000
+    if args.epochs is None:
+        args.epochs = 1500 if args.full else 400
+
+    families = [f.strip() for f in args.families.split(",") if f.strip()]
+    arms = [a.strip() for a in args.arms.split(",") if a.strip()]
+    for f in families:
+        if f not in FAMILIES:
+            raise SystemExit(f"unknown family {f!r}; known: {list(FAMILIES)}")
+    cp = [args.const, args.ate]
+    outdir = args.outdir or os.path.join(os.path.dirname(os.path.abspath(__file__)), "outputs")
+    os.makedirs(outdir, exist_ok=True)
+
+    tier = "FULL (hard ATE/mean gating)" if args.full else "SMOKE (runs-clean gated; ATE informational)"
+    print(f"tier={tier}")
+    print(f"families={families}  arms={arms}  n={args.n}  epochs={args.epochs}  seed={args.seed}")
+    print(f"causal_params=[const={args.const}, ate={args.ate}]\n")
+
+    key = jr.key(args.seed)
+    rows = []
+    for fi, fname in enumerate(families):
+        fam = FAMILIES[fname]
+        data = fam.generate(args.n, causal_params=cp, seed=args.seed)
+        X, Y, Z_disc, Z_cont = data["X"], data["Y"], data["Z_disc"], data["Z_cont"]
+        uz = causl_py.generate_uz_samples(Z_disc, Z_cont, False, args.seed, base_hyperparams(args.epochs))
+        u_z = uz["uz_samples"]
+        print(f"[{fname}] data X{tuple(X.shape)} Y{tuple(Y.shape)} u_z{tuple(u_z.shape)}  "
+              f"treated_frac={float(np.asarray(X).mean()):.3f}  true_ate={fam.true_ate(cp):+.3f}")
+        for ai, arm in enumerate(arms):
+            r = run_cell(jr.fold_in(key, 100 * fi + ai), fam, arm, Y, u_z, X, args)
+            if r.get("crashed"):
+                print(f"    {arm:22s} CRASHED: {r['crashed'][:80]}")
+            else:
+                print(f"    {arm:22s} ATE={r['ate']:+.3f} (true {r['true_ate']:+.3f}, err {r['ate_relerr']:.1%})  "
+                      f"tau_sd={r['tau_sd']:.3f}  E[Y|do]={r['mean0']:.2f}/{r['mean1']:.2f}  "
+                      f"frac_neg={r['frac_neg']:.2f}")
+            rows.append(r)
+        print()
+
+    # ---- numerical scorecard table ----
+    def mk(b):
+        return "OK" if b else "X"
+
+    hdr = (f"{'family':<10}{'arm':<22}{'ATE':>8}{'true':>8}{'relerr':>8}{'tau_sd':>8}"
+           f"{'runs':>6}{'ate':>5}{'mean':>6}  verdict")
+    print(hdr); print("-" * len(hdr))
+    for r in rows:
+        verdict = "PASS" if r["pass"] else "FAIL"
+        if r.get("crashed"):
+            print(f"{r['family']:<10}{r['arm']:<22}{'--':>8}{r['true_ate']:>8.2f}{'--':>8}{'--':>8}"
+                  f"{mk(False):>6}{mk(False):>5}{mk(False):>6}  CRASH")
+            continue
+        print(f"{r['family']:<10}{r['arm']:<22}{r['ate']:>8.3f}{r['true_ate']:>8.2f}{r['ate_relerr']:>7.1%}"
+              f"{r['tau_sd']:>8.3f}{mk(r['t_runs']):>6}{mk(r['t_ate']):>5}{mk(r['t_mean']):>6}  {verdict}")
+
+    # ---- figures ----
+    f1 = os.path.join(outdir, "ate_suite_margins.png")
+    f2 = os.path.join(outdir, "ate_suite_scorecard.png")
+    fig_margins(rows, families, arms, cp, f1, args.seed)
+    fig_scorecard(rows, families, arms, f2)
+    print(f"\nfigures: {f1}\n         {f2}")
+
+    overall = all(r["pass"] for r in rows)
+    gate = "smoke + ATE + mean" if args.full else "runs-clean only (ATE informational)"
+    print(f"\nOVERALL: {'PASS' if overall else 'FAIL'}  (gated: {gate})")
+    if not args.full:
+        print("note: ATE recovery is NOT gated in smoke tier (needs ~20k samples). Use --full for a hard check.")
+    sys.exit(0 if overall else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/diagnostics/ate_sweep.py
+++ b/validation/diagnostics/ate_sweep.py
@@ -1,0 +1,123 @@
+"""Sample-size sweep for ATE extraction: mean ATE + uncertainty over seeds.
+
+For a grid of (outcome family x causal-margin arm x n x seed) this fits the frugal
+flow, extracts the ATE model-agnostically (paired-CRN, dim 0 of the fitted flow at
+fixed T), and writes ONE CSV ROW PER FIT (summary stats only — no sample arrays).
+Rows are flushed incrementally so partial progress survives an interruption.
+
+It is designed to be SHARDED: run several instances over disjoint `--seeds`, each
+writing its own `--out` CSV; `ate_sweep_plot.py` concatenates `sweep_*.csv` and
+draws the mean +/- spread bands. (Separate files per shard => no write contention.)
+
+Usage (from validation/, in the frugal-flows-flowjax env):
+  micromamba run -n frugal-flows-flowjax python -m diagnostics.ate_sweep \
+      --ns 100,200,1000,2000,5000 --seeds 0,1 --out outputs/sweep_shard0.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sys
+import time
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp  # noqa: E402,F401
+import jax.random as jr  # noqa: E402
+import numpy as np  # noqa: E402
+
+_VALIDATION_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _VALIDATION_DIR not in sys.path:
+    sys.path.insert(0, _VALIDATION_DIR)
+
+import data_processing_and_simulations.causl_sim_data_generation as causl_py  # noqa: E402
+from diagnostics.ate_extraction_suite import intervene  # noqa: E402
+from diagnostics.outcome_families import FAMILIES  # noqa: E402
+from diagnostics.quick_sense_check import base_hyperparams, fit_model  # noqa: E402
+
+FIELDNAMES = [
+    "family", "arm", "n", "seed", "true_ate", "ate", "ate_relerr", "tau_sd",
+    "mean0", "mean1", "true_m0", "true_m1", "var0", "var1", "frac_neg",
+    "val_loss", "secs", "error",
+]
+
+
+def run(args):
+    ns = [int(x) for x in args.ns.split(",")]
+    seeds = [int(x) for x in args.seeds.split(",")]
+    families = [f.strip() for f in args.families.split(",") if f.strip()]
+    arms = [a.strip() for a in args.arms.split(",") if a.strip()]
+    cp = [args.const, args.ate]
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.out)), exist_ok=True)
+    total = len(families) * len(ns) * len(seeds) * len(arms)
+    done = 0
+    print(f"[shard {args.out}] grid: families={families} arms={arms} ns={ns} seeds={seeds} "
+          f"=> {total} fits  epochs={args.epochs}", flush=True)
+
+    with open(args.out, "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=FIELDNAMES)
+        w.writeheader()
+        fh.flush()
+        for fname in families:
+            fam = FAMILIES[fname]
+            true_ate = fam.true_ate(cp)
+            true_m0, true_m1 = fam.mean_do(cp, 0), fam.mean_do(cp, 1)
+            for n in ns:
+                for seed in seeds:
+                    # one dataset + one u_z per (family, n, seed); reused across arms
+                    data = fam.generate(n, causal_params=cp, seed=seed)
+                    X, Y, Z_disc, Z_cont = data["X"], data["Y"], data["Z_disc"], data["Z_cont"]
+                    uz = causl_py.generate_uz_samples(Z_disc, Z_cont, False, seed,
+                                                      base_hyperparams(args.epochs))
+                    u_z = uz["uz_samples"]
+                    for ai, arm in enumerate(arms):
+                        key = jr.key(1000 * seed + 13 * ai + 1)
+                        t0 = time.time()
+                        row = {k: "" for k in FIELDNAMES}
+                        row.update(family=fname, arm=arm, n=n, seed=seed,
+                                   true_ate=true_ate, true_m0=true_m0, true_m1=true_m1)
+                        try:
+                            ff, val_loss = fit_model(jr.fold_in(key, 1), Y, u_z, X, arm, args.epochs)
+                            m = intervene(jr.fold_in(key, 2), ff, X.shape[1], args.n_mc)
+                            ate = m["ate"]
+                            row.update(
+                                ate=ate,
+                                ate_relerr=abs(ate - true_ate) / max(abs(true_ate), 1e-8),
+                                tau_sd=m["tau_sd"], mean0=m["mean0"], mean1=m["mean1"],
+                                var0=m["var0"], var1=m["var1"], frac_neg=m["frac_neg"],
+                                val_loss=val_loss,
+                            )
+                        except Exception as e:  # noqa: BLE001 — keep sweeping
+                            row.update(ate=float("nan"), error=repr(e)[:200])
+                        row["secs"] = round(time.time() - t0, 1)
+                        w.writerow(row)
+                        fh.flush()
+                        done += 1
+                        tag = "ERR" if row["error"] else f"ate={float(row['ate']):+.3f}"
+                        print(f"[{args.out}] {done}/{total} {fname}/{arm} n={n} seed={seed} "
+                              f"{tag} ({row['secs']}s)", flush=True)
+    print(f"[shard {args.out}] DONE {done}/{total}", flush=True)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--families", default="gaussian,gamma")
+    p.add_argument("--arms", default="gaussian,flexible_continuous")
+    p.add_argument("--ns", default="100,200,1000,2000,5000")
+    p.add_argument("--seeds", default="0,1,2,3,4,5,6,7,8,9")
+    p.add_argument("--epochs", type=int, default=600)
+    p.add_argument("--n-mc", type=int, default=10000)
+    p.add_argument("--const", type=float, default=0.0)
+    p.add_argument("--ate", type=float, default=1.0)
+    p.add_argument("--out", required=True, help="output CSV path for THIS shard")
+    args = p.parse_args()
+    run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/diagnostics/ate_sweep_plot.py
+++ b/validation/diagnostics/ate_sweep_plot.py
@@ -1,0 +1,164 @@
+"""Aggregate the sharded ATE sweep and plot mean ATE +/- uncertainty vs n.
+
+Reads every `outputs/sweep_*.csv` (the shards from `ate_sweep.py`), pools the
+per-fit rows, and for each (family, arm, n) computes the mean ATE and its spread
+over seeds. Produces:
+
+  * ate_sweep_recovery.png  — ATE vs n (log x), one panel per outcome family;
+    per arm: mean line + shaded +/-1 SD band + individual-run dots; true ATE dashed.
+  * ate_sweep_relerr.png    — |relative error| vs n per arm/family (convergence),
+    with the 15% reference line.
+
+Also prints a numerical summary table (mean ATE, SD, SEM, mean rel-err, n_ok).
+
+Usage (from validation/):
+  micromamba run -n frugal-flows-flowjax python -m diagnostics.ate_sweep_plot
+  micromamba run -n frugal-flows-flowjax python -m diagnostics.ate_sweep_plot --glob 'outputs/sweep_*.csv'
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import matplotlib.ticker  # noqa: E402
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+ARM_LABEL = {"gaussian": "additive shift", "flexible_continuous": "spline",
+             "location_translation": "loc-translation"}
+ARM_COLOR = {"gaussian": "#d62728", "flexible_continuous": "#1f77b4",
+             "location_translation": "#2ca02c"}
+
+
+def load(pattern: str) -> pd.DataFrame:
+    paths = sorted(glob.glob(pattern if os.path.isabs(pattern) else os.path.join(_HERE, "..", pattern)))
+    if not paths:
+        paths = sorted(glob.glob(os.path.join(_HERE, "outputs", "sweep_*.csv")))
+    if not paths:
+        raise SystemExit(f"no sweep CSVs found for pattern {pattern!r}")
+    df = pd.concat([pd.read_csv(p) for p in paths], ignore_index=True)
+    print(f"loaded {len(df)} rows from {len(paths)} shard(s): {[os.path.basename(p) for p in paths]}")
+    n_err = df["error"].notna().sum() if "error" in df else 0
+    if n_err:
+        print(f"  {n_err} fits errored (dropped from ATE stats)")
+    df["ate"] = pd.to_numeric(df["ate"], errors="coerce")
+    return df
+
+
+def summarise(df: pd.DataFrame) -> pd.DataFrame:
+    ok = df.dropna(subset=["ate"])
+    g = ok.groupby(["family", "arm", "n"])
+    out = g.agg(
+        n_ok=("ate", "size"),
+        ate_mean=("ate", "mean"),
+        ate_sd=("ate", "std"),
+        true_ate=("true_ate", "first"),
+        relerr_mean=("ate_relerr", "mean"),
+        tau_sd_mean=("tau_sd", "mean"),
+        frac_neg_mean=("frac_neg", "mean"),
+    ).reset_index()
+    out["ate_sem"] = out["ate_sd"] / np.sqrt(out["n_ok"].clip(lower=1))
+    out["bias"] = out["ate_mean"] - out["true_ate"]
+    return out.sort_values(["family", "arm", "n"]).reset_index(drop=True)
+
+
+def fig_recovery(df: pd.DataFrame, summ: pd.DataFrame, outpath: str):
+    families = list(dict.fromkeys(summ["family"]))
+    arms = list(dict.fromkeys(summ["arm"]))
+    fig, axes = plt.subplots(1, len(families), figsize=(6.6 * len(families), 5.6), squeeze=False)
+    for j, fam in enumerate(families):
+        ax = axes[0][j]
+        true_ate = summ.loc[summ["family"] == fam, "true_ate"].iloc[0]
+        ax.axhline(true_ate, color="black", ls="--", lw=1.8, zorder=1,
+                   label=f"true ATE = {true_ate:+.2f}")
+        for arm in arms:
+            s = summ[(summ["family"] == fam) & (summ["arm"] == arm)].sort_values("n")
+            if s.empty:
+                continue
+            c = ARM_COLOR.get(arm, "gray")
+            ns = s["n"].to_numpy()
+            ax.plot(ns, s["ate_mean"], "-o", color=c, lw=2, ms=7, zorder=3,
+                    label=f"{ARM_LABEL.get(arm, arm)} (mean +/- SD)")
+            ax.fill_between(ns, s["ate_mean"] - s["ate_sd"], s["ate_mean"] + s["ate_sd"],
+                            color=c, alpha=0.18, zorder=2)
+            # individual runs, jittered horizontally on log scale
+            raw = df[(df["family"] == fam) & (df["arm"] == arm)].dropna(subset=["ate"])
+            jit = raw["n"] * np.random.default_rng(0).uniform(0.93, 1.07, len(raw))
+            ax.scatter(jit, raw["ate"], s=14, color=c, alpha=0.30, zorder=2, edgecolor="none")
+        ax.set_xscale("log")
+        ax.set_xticks(sorted(summ["n"].unique()))
+        ax.get_xaxis().set_major_formatter(matplotlib.ticker.ScalarFormatter())
+        ax.set_xlabel("training sample size n (log)", fontsize=12)
+        ax.set_ylabel("estimated ATE", fontsize=12)
+        ax.set_title(f"{fam} outcome", fontsize=14)
+        ax.grid(alpha=0.3)
+        ax.legend(fontsize=10, loc="best")
+    fig.suptitle("ATE recovery vs sample size (10 seeds/point; band = +/-1 SD)", fontsize=15)
+    fig.tight_layout(rect=[0, 0, 1, 0.96])
+    fig.savefig(outpath, dpi=120)
+    plt.close(fig)
+
+
+def fig_relerr(summ: pd.DataFrame, outpath: str):
+    families = list(dict.fromkeys(summ["family"]))
+    arms = list(dict.fromkeys(summ["arm"]))
+    fig, axes = plt.subplots(1, len(families), figsize=(6.6 * len(families), 5.2), squeeze=False)
+    for j, fam in enumerate(families):
+        ax = axes[0][j]
+        ax.axhline(0.15, color="gray", ls=":", lw=1.5, label="15% reference")
+        for arm in arms:
+            s = summ[(summ["family"] == fam) & (summ["arm"] == arm)].sort_values("n")
+            if s.empty:
+                continue
+            c = ARM_COLOR.get(arm, "gray")
+            ax.plot(s["n"], s["relerr_mean"], "-o", color=c, lw=2, ms=7,
+                    label=ARM_LABEL.get(arm, arm))
+        ax.set_xscale("log")
+        ax.set_yscale("log")
+        ax.set_xticks(sorted(summ["n"].unique()))
+        ax.get_xaxis().set_major_formatter(matplotlib.ticker.ScalarFormatter())
+        ax.set_xlabel("training sample size n (log)", fontsize=12)
+        ax.set_ylabel("mean |relative ATE error| (log)", fontsize=12)
+        ax.set_title(f"{fam} outcome", fontsize=14)
+        ax.grid(alpha=0.3, which="both")
+        ax.legend(fontsize=10, loc="best")
+    fig.suptitle("ATE relative error vs sample size", fontsize=15)
+    fig.tight_layout(rect=[0, 0, 1, 0.96])
+    fig.savefig(outpath, dpi=120)
+    plt.close(fig)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--glob", default="outputs/sweep_*.csv")
+    p.add_argument("--outdir", default=os.path.join(_HERE, "outputs"))
+    args = p.parse_args()
+
+    df = load(args.glob)
+    summ = summarise(df)
+    os.makedirs(args.outdir, exist_ok=True)
+    summ.to_csv(os.path.join(args.outdir, "ate_sweep_summary.csv"), index=False)
+
+    cols = ["family", "arm", "n", "n_ok", "true_ate", "ate_mean", "ate_sd", "ate_sem",
+            "relerr_mean", "tau_sd_mean", "frac_neg_mean"]
+    print("\n" + summ[cols].to_string(index=False,
+          float_format=lambda v: f"{v:+.3f}"))
+
+    f1 = os.path.join(args.outdir, "ate_sweep_recovery.png")
+    f2 = os.path.join(args.outdir, "ate_sweep_relerr.png")
+    fig_recovery(df, summ, f1)
+    fig_relerr(summ, f2)
+    print(f"\nfigures:\n  {f1}\n  {f2}")
+    print(f"summary CSV: {os.path.join(args.outdir, 'ate_sweep_summary.csv')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/diagnostics/d1_ate_recovery.py
+++ b/validation/diagnostics/d1_ate_recovery.py
@@ -1,0 +1,175 @@
+"""Diagnostic 1 — does the frugal flow identify the causal-margin parameters?
+
+Reproduces the core identification finding of ``Continous_Frugal_Flows.ipynb``:
+generate data with a KNOWN causal margin ``(ate, const, scale)``, fit the flow
+over several seeds, pull the learned margin params, and check they recover the
+truth.
+
+Output (written to ``validation/diagnostics/outputs/``):
+  * ``d1_<generator>_recovery.csv`` — per-seed recovered params + the truth.
+  * a printed summary table: recovered mean/std and bias vs truth.
+  * ``d1_<generator>_recovery.pdf`` — the notebook's boxplot of recovered
+    ate/const/scale with dashed lines at the true values.
+
+This is a *sense-check*, not a hard pass/fail test: a good fit shows the boxes
+centred on the dashed truth lines with the truth inside the spread.
+
+Run:
+    micromamba run -n frugal-flows-flowjax python -m diagnostics.d1_ate_recovery --smoke
+(from the ``validation/`` directory), or with explicit knobs:
+    ... d1_ate_recovery --generator mixed --const 1 --ate 1 --n-samples 20000 --n-iter 25
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless: write figures, never try to open a window
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from ._harness import (
+    DEFAULT_HYPERPARAMS,
+    PARAM_NAMES,
+    SMOKE_HYPERPARAMS,
+    fit_once,
+    outputs_dir,
+    true_params_from_causal_params,
+)
+
+
+def run_recovery(
+    generator_name: str,
+    causal_params,
+    n_samples: int,
+    n_iter: int,
+    seed: int,
+    hyperparams: dict,
+) -> pd.DataFrame:
+    """Fit ``n_iter`` times (seeds ``seed..seed+n_iter-1``); return recovered params.
+
+    Columns: ``ate, const, scale, seed, val_loss``. One row per fit.
+    """
+    rows = []
+    for i in range(n_iter):
+        s = seed + i
+        print(f"[d1] fit {i + 1}/{n_iter}  (generator={generator_name}, seed={s})")
+        res = fit_once(
+            generator_name=generator_name,
+            causal_params=causal_params,
+            n_samples=n_samples,
+            seed=s,
+            hyperparams=hyperparams,
+        )
+        rows.append({**res.recovered, "seed": s, "val_loss": res.val_loss})
+        r = res.recovered
+        print(
+            f"      recovered: ate={r['ate']:+.4f}  const={r['const']:+.4f}  "
+            f"scale={r['scale']:.4f}  (val_loss={res.val_loss:.4f})"
+        )
+    return pd.DataFrame(rows)
+
+
+def summarise(results: pd.DataFrame, true_params: dict) -> pd.DataFrame:
+    """Build a recovered-vs-truth summary table (mean, std, bias)."""
+    summary = pd.DataFrame(
+        {
+            "true": [true_params[p] for p in PARAM_NAMES],
+            "recovered_mean": [results[p].mean() for p in PARAM_NAMES],
+            "recovered_std": [results[p].std(ddof=1) for p in PARAM_NAMES],
+        },
+        index=list(PARAM_NAMES),
+    )
+    summary["bias"] = summary["recovered_mean"] - summary["true"]
+    return summary
+
+
+def plot_recovery(results: pd.DataFrame, true_params: dict, save_path: str) -> None:
+    """Boxplot of recovered ate/const/scale with dashed lines at the truth.
+
+    Mirrors the notebook's ``plot_simulation_results`` (kept script-local rather
+    than importing it, so this folder stays self-contained and we are not coupled
+    to that module's globals).
+    """
+    plt.figure(figsize=(10, 6))
+    results.boxplot(column=list(PARAM_NAMES), grid=False)
+    colors = {"ate": "r", "const": "g", "scale": "b"}
+    for p in PARAM_NAMES:
+        plt.axhline(y=true_params[p], color=colors[p], linestyle="--", label=f"true {p}")
+    plt.title("Causal-margin parameter recovery")
+    plt.ylabel("value")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(save_path)
+    plt.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--generator",
+        default="mixed",
+        choices=["gaussian", "mixed", "discrete", "many_discrete"],
+        help="which causl ground-truth generator to use (default: mixed)",
+    )
+    parser.add_argument("--const", type=float, default=1.0, help="true const (causal_params[0])")
+    parser.add_argument("--ate", type=float, default=1.0, help="true ate (causal_params[1])")
+    parser.add_argument("--n-samples", type=int, default=20000, help="samples per fit")
+    parser.add_argument("--n-iter", type=int, default=25, help="number of seeds/fits")
+    parser.add_argument("--seed", type=int, default=0, help="base seed")
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="fast feedback config: small n-samples/n-iter and short training",
+    )
+    parser.add_argument("--max-epochs", type=int, default=None, help="override max_epochs")
+    parser.add_argument("--max-patience", type=int, default=None, help="override max_patience")
+    parser.add_argument("--outdir", default=None, help="output directory (default: diagnostics/outputs)")
+    args = parser.parse_args()
+
+    causal_params = [args.const, args.ate]
+    true_params = true_params_from_causal_params(causal_params)
+
+    if args.smoke:
+        hyperparams = dict(SMOKE_HYPERPARAMS)
+        n_samples = min(args.n_samples, 2000) if args.n_samples == 20000 else args.n_samples
+        n_iter = min(args.n_iter, 3) if args.n_iter == 25 else args.n_iter
+    else:
+        hyperparams = dict(DEFAULT_HYPERPARAMS)
+        n_samples, n_iter = args.n_samples, args.n_iter
+    if args.max_epochs is not None:
+        hyperparams["max_epochs"] = args.max_epochs
+    if args.max_patience is not None:
+        hyperparams["max_patience"] = args.max_patience
+
+    outdir = args.outdir or outputs_dir()
+    os.makedirs(outdir, exist_ok=True)
+
+    print(
+        f"[d1] generator={args.generator}  causal_params=[const={args.const}, ate={args.ate}]  "
+        f"-> truth {true_params}\n"
+        f"     n_samples={n_samples}  n_iter={n_iter}  "
+        f"max_epochs={hyperparams['max_epochs']}  max_patience={hyperparams['max_patience']}"
+    )
+
+    results = run_recovery(args.generator, causal_params, n_samples, n_iter, args.seed, hyperparams)
+
+    csv_path = os.path.join(outdir, f"d1_{args.generator}_recovery.csv")
+    results.to_csv(csv_path, index=False)
+
+    summary = summarise(results, true_params)
+    print("\n[d1] recovered vs truth:\n")
+    print(summary.to_string(float_format=lambda v: f"{v:+.4f}"))
+
+    fig_path = os.path.join(outdir, f"d1_{args.generator}_recovery.pdf")
+    plot_recovery(results, true_params, fig_path)
+
+    print(f"\n[d1] wrote:\n  {csv_path}\n  {fig_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/diagnostics/d2_margin_shape.py
+++ b/validation/diagnostics/d2_margin_shape.py
@@ -1,0 +1,171 @@
+"""Diagnostic 2 — what does the learned causal margin look like?
+
+Goal 2 from the meeting: don't just read the scalar ATE, *look* at the margin.
+For the current Gaussian/location-translation model the margin is a
+``UnivariateNormalCDF`` whose inverse is the outcome quantile function under an
+intervention ``do(X=x)``:
+
+    Q_x(u) = Phi^{-1}(u) * scale + (ate * x + const)
+
+So the implied interventional outcome is Gaussian with mean ``ate*x + const`` and
+sd ``scale``. Plotting ``Q_0`` and ``Q_1`` (i.e. ``do(X=0)`` vs ``do(X=1)``) makes
+the treatment effect visible as the *gap* between the two curves. For this
+additive-shift model the gap is constant in ``u`` and equals ``ate``.
+
+Why this diagnostic matters going forward: when the margin is later replaced by a
+treatment-conditioned spline, the gap will no longer be constant — you will be
+able to *see* heterogeneity that a single scalar ATE cannot express. This script
+is the tool that will show that.
+
+Sense-checks printed:
+  * scale > 0 (the bijection's scale is unconstrained — see UnivariateNormalCDF
+    warning; a fit can in principle drive it negative).
+  * Q_x monotone increasing in u (well-posed quantile function).
+  * measured gap Q_1 - Q_0 is (near-)constant and equals the recovered ate.
+
+Output: ``d2_<generator>_margin.pdf`` — left: the two quantile curves; right: the
+two implied outcome densities.
+
+Run (from validation/):
+    micromamba run -n frugal-flows-flowjax python -m diagnostics.d2_margin_shape --smoke
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.stats import norm
+
+from ._harness import DEFAULT_HYPERPARAMS, SMOKE_HYPERPARAMS, fit_once, outputs_dir
+
+
+def margin_quantiles(recovered: dict, u: np.ndarray, x: float) -> np.ndarray:
+    """Interventional outcome quantile function ``Q_x(u)`` for ``do(X=x)``.
+
+    Closed form of ``UnivariateNormalCDF.inverse`` (see its docstring):
+    ``ndtri(u) * scale + (ate * x + const)``.
+    """
+    loc = recovered["ate"] * x + recovered["const"]
+    return norm.ppf(u) * recovered["scale"] + loc
+
+
+def sense_checks(recovered: dict, u: np.ndarray) -> dict:
+    """Return the diagnostic sense-checks as a dict (also printed by main)."""
+    q0 = margin_quantiles(recovered, u, 0.0)
+    q1 = margin_quantiles(recovered, u, 1.0)
+    gap = q1 - q0  # constant == ate for the Gaussian margin
+    return {
+        "scale_positive": bool(recovered["scale"] > 0),
+        "q0_monotone": bool(np.all(np.diff(q0) > 0)),
+        "q1_monotone": bool(np.all(np.diff(q1) > 0)),
+        "gap_mean": float(np.mean(gap)),
+        "gap_max_dev": float(np.max(np.abs(gap - np.mean(gap)))),
+        "gap_matches_ate": bool(np.allclose(gap, recovered["ate"], atol=1e-6)),
+    }
+
+
+def plot_margin(recovered: dict, true_params: dict, save_path: str) -> None:
+    u = np.linspace(1e-3, 1 - 1e-3, 400)
+    q0 = margin_quantiles(recovered, u, 0.0)
+    q1 = margin_quantiles(recovered, u, 1.0)
+
+    fig, (ax_q, ax_d) = plt.subplots(1, 2, figsize=(13, 5))
+
+    # Left: quantile functions, gap = ATE.
+    ax_q.plot(u, q0, label="do(X=0):  $Q_0(u)$", color="tab:blue")
+    ax_q.plot(u, q1, label="do(X=1):  $Q_1(u)$", color="tab:orange")
+    mid = len(u) // 2
+    ax_q.annotate(
+        "",
+        xy=(u[mid], q1[mid]),
+        xytext=(u[mid], q0[mid]),
+        arrowprops=dict(arrowstyle="<->", color="k"),
+    )
+    ax_q.text(
+        u[mid] + 0.02,
+        0.5 * (q0[mid] + q1[mid]),
+        f"gap = ATE = {recovered['ate']:.3f}\n(true {true_params['ate']:.3f})",
+        va="center",
+    )
+    ax_q.set_xlabel("quantile $u$")
+    ax_q.set_ylabel("outcome $Y$")
+    ax_q.set_title("Interventional outcome quantile functions")
+    ax_q.legend()
+
+    # Right: implied outcome densities (Gaussian: mean = ate*x + const, sd = scale).
+    lo = min(q0.min(), q1.min())
+    hi = max(q0.max(), q1.max())
+    grid = np.linspace(lo, hi, 400)
+    for x, color, lab in [(0.0, "tab:blue", "do(X=0)"), (1.0, "tab:orange", "do(X=1)")]:
+        loc = recovered["ate"] * x + recovered["const"]
+        ax_d.plot(grid, norm.pdf(grid, loc=loc, scale=recovered["scale"]), color=color, label=lab)
+        ax_d.axvline(loc, color=color, linestyle=":", alpha=0.7)
+    ax_d.set_xlabel("outcome $Y$")
+    ax_d.set_ylabel("density")
+    ax_d.set_title("Implied $p(Y \\mid do(X))$")
+    ax_d.legend()
+
+    fig.suptitle(
+        f"Learned causal margin  "
+        f"(ate={recovered['ate']:.3f}, const={recovered['const']:.3f}, scale={recovered['scale']:.3f})"
+    )
+    fig.tight_layout()
+    fig.savefig(save_path)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--generator", default="mixed", choices=["gaussian", "mixed", "discrete", "many_discrete"]
+    )
+    parser.add_argument("--const", type=float, default=1.0, help="true const (causal_params[0])")
+    parser.add_argument("--ate", type=float, default=1.0, help="true ate (causal_params[1])")
+    parser.add_argument("--n-samples", type=int, default=20000)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--smoke", action="store_true", help="fast feedback config")
+    parser.add_argument("--max-epochs", type=int, default=None)
+    parser.add_argument("--max-patience", type=int, default=None)
+    parser.add_argument("--outdir", default=None)
+    args = parser.parse_args()
+
+    causal_params = [args.const, args.ate]
+    hyperparams = dict(SMOKE_HYPERPARAMS if args.smoke else DEFAULT_HYPERPARAMS)
+    n_samples = (min(args.n_samples, 2000) if (args.smoke and args.n_samples == 20000) else args.n_samples)
+    if args.max_epochs is not None:
+        hyperparams["max_epochs"] = args.max_epochs
+    if args.max_patience is not None:
+        hyperparams["max_patience"] = args.max_patience
+
+    outdir = args.outdir or outputs_dir()
+    os.makedirs(outdir, exist_ok=True)
+
+    print(f"[d2] fitting once: generator={args.generator}, causal_params={causal_params}, n={n_samples}")
+    res = fit_once(
+        generator_name=args.generator,
+        causal_params=causal_params,
+        n_samples=n_samples,
+        seed=args.seed,
+        hyperparams=hyperparams,
+    )
+    print(f"[d2] recovered: {res.recovered}   true: {res.true_params}")
+
+    u = np.linspace(1e-3, 1 - 1e-3, 400)
+    checks = sense_checks(res.recovered, u)
+    print("\n[d2] sense-checks:")
+    for k, v in checks.items():
+        print(f"      {k}: {v}")
+
+    fig_path = os.path.join(outdir, f"d2_{args.generator}_margin.pdf")
+    plot_margin(res.recovered, res.true_params, fig_path)
+    print(f"\n[d2] wrote:\n  {fig_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/diagnostics/d3_moment_match.py
+++ b/validation/diagnostics/d3_moment_match.py
@@ -1,0 +1,176 @@
+"""Diagnostic 3 — are the treatment/covariate summary stats what causl intended?
+
+Goal 3 from the meeting: check the mean/variance of the treatment X and the
+confounders Z against their causl ground truth.
+
+Ground truth comes from causl itself, two ways:
+  * **Monte-Carlo reference (primary):** a large ``causalSamp`` draw (default 100k)
+    from the SAME generator. Its empirical moments are the population values for
+    *every* variable — including the treatment X, which is binomial *conditional*
+    on Z (``X~Z``) and so has no closed-form marginal mean. This is the universal,
+    robust route and is what we compare against.
+  * **Closed-form cross-check (where it applies):** for intercept-only covariates
+    (``Z~1``) the causl conventions give exact moments — Gamma: mean ``exp(beta)``,
+    var ``phi*exp(beta)^2``; binomial: ``p=expit(beta)``, var ``p(1-p)``; gaussian:
+    mean ``beta``, var ``phi`` (see ``reference_causl-conventions`` in memory /
+    the README). Generators with conditional covariates (e.g. ``gaussian``:
+    ``Zc2~Zc1``) have no per-covariate closed form — the MC reference covers them.
+
+What this measures: how faithfully a *fit-sized* dataset (``n_samples``) reproduces
+the population treatment/covariate distribution. Large gaps at small ``n`` mean the
+inputs the flow is trained on are noisy — directly relevant to the ATE-recovery /
+data-efficiency question (noisy inputs -> noisier ATE).
+
+NB: this v1 compares causl-truth vs the *generated data*. A later mode 2 will swap
+the data side for the flow's *reconstruction* of X/Z (does the model distort the
+covariates?) — that needs the FrugalFlowModel sampler and is added separately,
+still without touching core code.
+
+Output:
+  * ``d3_<generator>_moments.csv`` — per-variable causl-ref vs sample mean/var + deltas.
+  * printed table.
+  * ``d3_<generator>_moments.pdf`` — per-variable overlaid histograms (ref vs sample).
+
+Run (from validation/):
+    micromamba run -n frugal-flows-flowjax python -m diagnostics.d3_moment_match --smoke
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from ._harness import generate_dataset, outputs_dir
+
+
+def labelled_columns(data: dict) -> dict[str, np.ndarray]:
+    """Flatten a generator's data dict into ``{label: 1d array}`` for X and each Z.
+
+    Y is excluded — this diagnostic is about the treatment and confounders only.
+    """
+    cols: dict[str, np.ndarray] = {}
+    cols["X (treatment)"] = np.asarray(data["X"]).reshape(-1)
+    if data.get("Z_cont") is not None:
+        zc = np.asarray(data["Z_cont"])
+        for j in range(zc.shape[1]):
+            cols[f"Zc{j + 1}"] = zc[:, j]
+    if data.get("Z_disc") is not None:
+        zd = np.asarray(data["Z_disc"])
+        for j in range(zd.shape[1]):
+            cols[f"Zd{j + 1}"] = zd[:, j]
+    return cols
+
+
+def moment_table(reference: dict, sample: dict) -> pd.DataFrame:
+    """Per-variable causl-reference vs sample mean/var, with absolute deltas."""
+    rows = []
+    for label in reference:
+        r, s = reference[label], sample[label]
+        r_mean, r_var = float(np.mean(r)), float(np.var(r, ddof=1))
+        s_mean, s_var = float(np.mean(s)), float(np.var(s, ddof=1))
+        rows.append(
+            {
+                "variable": label,
+                "causl_mean": r_mean,
+                "sample_mean": s_mean,
+                "d_mean": s_mean - r_mean,
+                "causl_var": r_var,
+                "sample_var": s_var,
+                "d_var": s_var - r_var,
+            }
+        )
+    return pd.DataFrame(rows).set_index("variable")
+
+
+def plot_moments(reference: dict, sample: dict, save_path: str, ref_n: int, samp_n: int) -> None:
+    labels = list(reference)
+    ncols = min(3, len(labels))
+    nrows = math.ceil(len(labels) / ncols)
+    fig, axes = plt.subplots(nrows, ncols, figsize=(5 * ncols, 3.4 * nrows), squeeze=False)
+    for ax, label in zip(axes.ravel(), labels):
+        r, s = reference[label], sample[label]
+        lo, hi = float(min(r.min(), s.min())), float(max(r.max(), s.max()))
+        # discrete-ish (few unique values) -> one bin centred on each value (edges at
+        # value +/- 0.5) so e.g. binary {0,1} shows two separated bars; else 40 bins.
+        uniq = np.unique(np.concatenate([np.unique(r), np.unique(s)]))
+        if uniq.size <= 10:
+            bins = np.concatenate([uniq - 0.5, [uniq[-1] + 0.5]])
+        else:
+            bins = np.linspace(lo, hi, 41)
+        ax.hist(r, bins=bins, density=True, alpha=0.45, label=f"causl ref (N={ref_n})", color="tab:gray")
+        ax.hist(s, bins=bins, density=True, alpha=0.55, label=f"sample (n={samp_n})", color="tab:blue")
+        ax.axvline(np.mean(r), color="k", linestyle="--", linewidth=1)
+        ax.axvline(np.mean(s), color="tab:blue", linestyle="--", linewidth=1)
+        ax.set_title(label)
+    # blank any unused panels
+    for ax in axes.ravel()[len(labels):]:
+        ax.set_visible(False)
+    axes.ravel()[0].legend(fontsize=8)
+    fig.suptitle("Treatment / covariate moments: causl reference vs fit-sized sample")
+    fig.tight_layout()
+    fig.savefig(save_path)
+    plt.close(fig)
+
+
+def run_moment_match(
+    generator_name: str, causal_params, n_samples: int, ref_n: int, seed: int
+) -> tuple[pd.DataFrame, dict, dict]:
+    """Draw a large causl reference and a fit-sized sample; return table + raw columns."""
+    print(f"[d3] drawing causl reference (N={ref_n}) ...")
+    ref_data = generate_dataset(generator_name, causal_params, ref_n, seed=seed + 9999)
+    print(f"[d3] drawing fit-sized sample (n={n_samples}) ...")
+    samp_data = generate_dataset(generator_name, causal_params, n_samples, seed=seed)
+
+    reference = labelled_columns(ref_data)
+    sample = labelled_columns(samp_data)
+    table = moment_table(reference, sample)
+    return table, reference, sample
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--generator", default="mixed", choices=["gaussian", "mixed", "discrete", "many_discrete"]
+    )
+    parser.add_argument("--const", type=float, default=1.0, help="true const (causal_params[0])")
+    parser.add_argument("--ate", type=float, default=1.0, help="true ate (causal_params[1])")
+    parser.add_argument("--n-samples", type=int, default=20000, help="fit-sized sample")
+    parser.add_argument("--ref-n", type=int, default=100000, help="causl Monte-Carlo reference size")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--smoke", action="store_true", help="fast: small sample + reference")
+    parser.add_argument("--outdir", default=None)
+    args = parser.parse_args()
+
+    causal_params = [args.const, args.ate]
+    if args.smoke:
+        n_samples = min(args.n_samples, 2000) if args.n_samples == 20000 else args.n_samples
+        ref_n = min(args.ref_n, 20000) if args.ref_n == 100000 else args.ref_n
+    else:
+        n_samples, ref_n = args.n_samples, args.ref_n
+
+    outdir = args.outdir or outputs_dir()
+    os.makedirs(outdir, exist_ok=True)
+
+    print(f"[d3] generator={args.generator}  causal_params={causal_params}  n_samples={n_samples}  ref_n={ref_n}")
+    table, reference, sample = run_moment_match(args.generator, causal_params, n_samples, ref_n, args.seed)
+
+    csv_path = os.path.join(outdir, f"d3_{args.generator}_moments.csv")
+    table.to_csv(csv_path)
+    print("\n[d3] treatment/covariate moments (causl reference vs sample):\n")
+    print(table.to_string(float_format=lambda v: f"{v:+.4f}"))
+
+    fig_path = os.path.join(outdir, f"d3_{args.generator}_moments.pdf")
+    plot_moments(reference, sample, fig_path, ref_n, n_samples)
+    print(f"\n[d3] wrote:\n  {csv_path}\n  {fig_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/diagnostics/outcome_families.py
+++ b/validation/diagnostics/outcome_families.py
@@ -1,0 +1,267 @@
+"""Causl ground-truth generators parameterised by OUTCOME family.
+
+The existing `causl_sim_data_generation.py` generators all use a Gaussian
+*outcome* (`Y` family 1, identity link); their `3`/`5` family codes describe the
+*confounders* `Z` and treatment `X`, not `Y`. This module adds generators that
+vary the **outcome** family so we can ask the same question — *can the frugal
+flow extract the ATE?* — across continuous outcome distributions (Gaussian,
+Gamma, ...).
+
+It is purely additive: it only builds R scripts and hands them to the existing
+`causl_py.generate_data_samples`, reusing the same rpy2 plumbing and the same
+`{Z_disc, Z_cont, X, Y}` output contract. Nothing in the core package or the
+existing validation modules is modified.
+
+Each family is described by an `OutcomeFamily` spec that ALSO carries the
+*correct* ground truth, because the truth depends on the link:
+
+    Gaussian (family 1, identity link):
+        E[Y | do(X=t)] = const + ate * t
+        true ATE       = ate
+        Var[Y | do(X)] = phi
+
+    Gamma (family 3, log link):
+        E[Y | do(X=t)] = exp(const + ate * t)          (MULTIPLICATIVE effect)
+        true ATE       = exp(const + ate) - exp(const)  (NON-additive in the mean)
+        Var[Y | do(X)] = phi * E[Y | do(X)]^2
+
+The Gamma case is therefore the decisive non-additive test: a location-shift
+causal margin (`causal_model='gaussian'`) is misspecified for it, while the
+treatment-conditioned spline (`flexible_continuous`) can adapt.
+
+Link/parameterisation verified against the d3 causl-conventions table
+(project memory `reference-causl-conventions`):
+    family | code | link     | mean      | variance
+    gauss  |  1   | identity | beta      | phi
+    gamma  |  3   | log      | exp(beta) | phi * exp(beta)^2
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sys
+from dataclasses import dataclass
+from typing import Callable
+
+import numpy as np
+
+# Make the existing validation package importable from validation/diagnostics/.
+_VALIDATION_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _VALIDATION_DIR not in sys.path:
+    sys.path.insert(0, _VALIDATION_DIR)
+
+import data_processing_and_simulations.causl_sim_data_generation as causl_py  # noqa: E402
+
+
+@dataclass(frozen=True)
+class OutcomeFamily:
+    """One outcome-family generator + its analytic ground truth.
+
+    Attributes:
+        name: short handle (e.g. "gaussian", "gamma").
+        y_family: causl family code for Y (1 = Gaussian, 3 = Gamma).
+        link: "identity" or "log" — how `const + ate*X` maps to E[Y|do(X)].
+        phi: causl dispersion for Y.
+        generate: callable (N, causal_params, seed) -> {Z_disc, Z_cont, X, Y}.
+    """
+
+    name: str
+    y_family: int
+    link: str
+    phi: float
+    generate: Callable
+
+    # ---- analytic ground truth (depends on the link) -------------------------
+    def mean_do(self, causal_params, t: int) -> float:
+        const, ate = float(causal_params[0]), float(causal_params[1])
+        lin = const + ate * t
+        return lin if self.link == "identity" else math.exp(lin)
+
+    def true_ate(self, causal_params) -> float:
+        return self.mean_do(causal_params, 1) - self.mean_do(causal_params, 0)
+
+    def var_do(self, causal_params, t: int) -> float:
+        m = self.mean_do(causal_params, t)
+        return self.phi if self.link == "identity" else self.phi * m * m
+
+    def true_tau_curve(self, causal_params, u_grid) -> np.ndarray:
+        """Analytic paired treatment effect tau(u) = Q_{do1}(u) - Q_{do0}(u).
+
+        This is the GROUND-TRUTH per-quantile effect the paired-CRN readout
+        estimates (same base draw pushed through do(0) and do(1)):
+
+          identity link (Gaussian): both interventional margins are N(mean_t, phi),
+              so Q_{do1}(u) - Q_{do0}(u) = mean1 - mean0 = ATE for every u
+              => tau(u) is FLAT. Any spread the spline shows here is SPURIOUS.
+
+          log link (Gamma): p(Y|do(t)) is Gamma(shape k=1/phi, scale theta_t=mean_t*phi),
+              whose quantile is theta_t * G^{-1}(u; k). Hence
+              tau(u) = (theta1 - theta0) * G^{-1}(u; k),
+              which GROWS with u (a genuine, multiplicative effect heterogeneity).
+              Here tau_sd>0 is CORRECT, so Gamma is the positive control.
+
+        Needs scipy for the Gamma quantile; raises if unavailable on that path.
+        """
+        u = np.asarray(u_grid, dtype=float)
+        if self.link == "identity":
+            return np.full_like(u, self.true_ate(causal_params))
+        # log link (Gamma)
+        from scipy.stats import gamma as _gamma  # local import: only needed here
+        k = 1.0 / self.phi
+        theta0 = self.mean_do(causal_params, 0) * self.phi
+        theta1 = self.mean_do(causal_params, 1) * self.phi
+        g = _gamma.ppf(u, a=k)
+        return (theta1 - theta0) * g
+
+    def sample_truth(self, causal_params, t: int, n: int, rng: np.random.Generator) -> np.ndarray:
+        """Draw n iid samples from the TRUE interventional margin p(Y | do(X=t)).
+
+        Used only to overlay the ground-truth shape on the figures. Valid because
+        the frugal parametrisation specifies Y's causal margin directly, so
+        p(Y | do(X=t)) is exactly this outcome family with the linked mean.
+        """
+        m = self.mean_do(causal_params, t)
+        if self.link == "identity":
+            return rng.normal(loc=m, scale=math.sqrt(self.phi), size=n)
+        # Gamma, log link: shape k = 1/phi, scale theta = mean * phi (so mean = k*theta).
+        k = 1.0 / self.phi
+        theta = m * self.phi
+        return rng.gamma(shape=k, scale=theta, size=n)
+
+
+def _confound_coef(confounded: bool, confound_beta: float | None) -> float:
+    """Resolve the Z->X propensity coefficient magnitude beta.
+
+    Backward-compatible with the original boolean `confounded` toggle:
+      confound_beta is None -> beta = 1.0 if confounded else 0.0  (the old on/off).
+      confound_beta given    -> beta = confound_beta               (continuous knob).
+    beta scales the coefficients on Zc1,Zc2,Zc3 in the X propensity equally, so
+    beta=0 is X ⟂ Z (unconfounded), beta=1 reproduces the original confounded DGP,
+    and beta>1 strengthens the backdoor.
+    """
+    if confound_beta is not None:
+        return float(confound_beta)
+    return 1.0 if confounded else 0.0
+
+
+def _build_rscript(N: int, causal_params, seed: int, y_family: int, y_phi: float,
+                   confounded: bool = True, confound_beta: float | None = None) -> str:
+    """Causl R script: 4 Gaussian confounders, binary X, outcome family `y_family`.
+
+    The confounder / treatment / copula structure is held FIXED across families
+    (copied from `generate_gaussian_samples`) so that only the outcome family
+    varies between specs — an apples-to-apples comparison of outcome distributions.
+
+    The Z->X (propensity) dependence is set by a coefficient `beta` (see
+    `_confound_coef`): X = c(0, beta, beta, beta) on (intercept, Zc1, Zc2, Zc3).
+      beta = 0 -> treatment depends only on the intercept => X ⟂ Z (unconfounded).
+      beta = 1 -> the original confounded DGP (Zc1..Zc3 each with coefficient 1).
+      beta > 1 -> stronger backdoor.
+    The Y->Z copula is left untouched; only the *treatment* arm of the confounding
+    backdoor is scaled, which is what modulates the copula's overlap with the
+    T-effect (the driver the bias diagnostics probe).
+    """
+    c0, a0 = causal_params[0], causal_params[1]
+    beta = _confound_coef(confounded, confound_beta)
+    x_beta = f"c(0,{beta},{beta},{beta})"
+    return f"""
+    library(causl)
+    pars <- list(Zc1 = list(beta = 0, phi=1),
+                 Zc2 = list(beta = c(1,1), phi=1),
+                 Zc3 = list(beta = c(1,1), phi=1),
+                 Zc4 = list(beta = c(0,1,1,1), phi=0.5),
+                 X = list(beta = {x_beta}),
+                 Y = list(beta = c({c0}, {a0}), phi={y_phi}),
+                 cop = list(beta=matrix(c(2,1,0.5,1,1,1,1,1,1,1), nrow=1)))
+
+    set.seed({seed})
+    fams <- list(c(1,1,1,1), 5, {y_family}, 1)
+    data_samples <- causalSamp({N}, formulas=list(list(Zc1~1, Zc2~Zc1, Zc3~Zc1, Zc4~Zc3+Zc2+Zc1), X~Zc1+Zc2+Zc3, Y~X, ~1), family=fams, pars=pars)
+    """
+
+
+def _make_generator(y_family: int, y_phi: float, confounded: bool = True,
+                    confound_beta: float | None = None):
+    def _gen(N, causal_params, seed=0):
+        return causl_py.generate_data_samples(
+            _build_rscript(N, causal_params, seed, y_family, y_phi,
+                           confounded, confound_beta))
+    return _gen
+
+
+def make_gaussian_family(confound_beta: float) -> "OutcomeFamily":
+    """Gaussian-outcome family with a chosen Z->X confounding strength `beta`.
+
+    Same analytic ground truth as `FAMILIES['gaussian']` (identity link, phi=1),
+    but the propensity backdoor coefficient is `confound_beta` instead of the
+    default 1.0. Used by the confounding-strength sweep (E2) to trace how the
+    spline arm's spurious effect heterogeneity scales with confounding.
+    """
+    return OutcomeFamily(
+        name=f"gaussian_b{confound_beta:g}", y_family=1, link="identity", phi=1.0,
+        generate=_make_generator(1, 1.0, confound_beta=confound_beta),
+    )
+
+
+# Registry of outcome families. Add new continuous families here (e.g. inverse
+# Gaussian) and the suite picks them up automatically.
+GAMMA_PHI = 0.5  # shape = 1/phi = 2: clearly right-skewed but stable to fit
+
+
+def make_gamma_family(confound_beta: float) -> "OutcomeFamily":
+    """Gamma-outcome family (log link, phi=GAMMA_PHI) with a chosen Z->X strength `beta`.
+
+    Same analytic ground truth as `FAMILIES['gamma']` (log link => multiplicative
+    effect, so `true_ate`/`true_tau_curve` are beta-INDEPENDENT — beta only touches
+    the Z->X propensity backdoor, not the causal margin). Used by the overlap
+    dose-response sweep (E-vii(b)): beta=0 is X ⟂ Z (perfect overlap), beta=1 is the
+    original confounded gamma DGP, beta>1 worsens positivity. `gamma_b1` reproduces
+    `FAMILIES['gamma']` exactly (a built-in consistency check).
+    """
+    return OutcomeFamily(
+        name=f"gamma_b{confound_beta:g}", y_family=3, link="log", phi=GAMMA_PHI,
+        generate=_make_generator(3, GAMMA_PHI, confound_beta=confound_beta),
+    )
+
+
+FAMILIES: dict[str, OutcomeFamily] = {
+    "gaussian": OutcomeFamily(
+        name="gaussian", y_family=1, link="identity", phi=1.0,
+        generate=_make_generator(1, 1.0),
+    ),
+    "gamma": OutcomeFamily(
+        name="gamma", y_family=3, link="log", phi=GAMMA_PHI,
+        generate=_make_generator(3, GAMMA_PHI),
+    ),
+    # Unconfounded twin of `gaussian` (X ⟂ Z): same causal-margin truth, but no
+    # Z->X backdoor. Used by the bias diagnostics to test whether the small-n ATE
+    # attenuation is driven by the copula absorbing the confounded treatment effect.
+    "gaussian_unconfounded": OutcomeFamily(
+        name="gaussian_unconfounded", y_family=1, link="identity", phi=1.0,
+        generate=_make_generator(1, 1.0, confounded=False),
+    ),
+    # Overlap dose-response sweep (E-vii(b)): the same Gamma DGP at increasing
+    # Z->X confounding strength beta. beta=0 is unconfounded (perfect overlap);
+    # beta=1.5 is the worst positivity. `gamma_b1` == `gamma` (consistency check).
+    **{f"gamma_b{b:g}": make_gamma_family(b) for b in (0.0, 0.5, 1.0, 1.5)},
+}
+
+
+if __name__ == "__main__":
+    # Cheap self-test: generate a small dataset per family and check the EMPIRICAL
+    # treated/untreated outcome means line up with the analytic linked truth.
+    cp = [0.0, 1.0]
+    for name, fam in FAMILIES.items():
+        d = fam.generate(2000, causal_params=cp, seed=0)
+        Y = np.asarray(d["Y"]).ravel()
+        X = np.asarray(d["X"]).ravel()
+        emp0, emp1 = Y[X == 0].mean(), Y[X == 1].mean()
+        # NB: empirical means are CONDITIONAL E[Y|X], not interventional, so they
+        # carry confounding bias; this is a sanity check on order of magnitude,
+        # not an identification claim.
+        print(f"{name:9s} y_family={fam.y_family} link={fam.link} phi={fam.phi}")
+        print(f"  true do-means: E[Y|do0]={fam.mean_do(cp,0):.3f}  E[Y|do1]={fam.mean_do(cp,1):.3f}"
+              f"  true ATE={fam.true_ate(cp):+.3f}")
+        print(f"  empir  E[Y|X=0]={emp0:.3f}  E[Y|X=1]={emp1:.3f}  (confounded; rough check)")
+        print(f"  Y range: [{Y.min():.2f}, {Y.max():.2f}]  any<=0: {(Y<=0).any()}\n")

--- a/validation/diagnostics/quick_sense_check.py
+++ b/validation/diagnostics/quick_sense_check.py
@@ -1,0 +1,223 @@
+"""Quick causl-backed sense check for frugal-flow causal models.
+
+A fast (no-notebook) smoke test you can rerun per model and eyeball side by side.
+Generates a small dataset from the R `causl` package (known true ATE + known
+interventional moments), fits the frugal flow for each requested causal_model,
+and runs three sense checks:
+
+  1. TRAIN   — finite val loss; no NaNs in interventional samples.
+  2. ATE     — post-hoc ATE within --tol (relative) of the true causl ATE.
+  3. MOMENTS — sampled E[Y|do(T=0)] ~ const, E[Y|do(T=1)] ~ const+ate,
+               Var[Y|do(T)] ~ phi  (absolute tol).
+
+The ATE / moments are read out MODEL-AGNOSTICALLY: sample the full fitted flow
+at a fixed treatment T and read dim 0 (Y). Valid because the copula masks T
+(mask_condition=True), so the flow's Y-marginal at externally-fixed T equals
+p(Y | do(T)). This avoids the gaussian-only margin extraction in frugal_fitting.
+
+Usage (from repo root, in the frugal-flows-flowjax env):
+  micromamba run -n frugal-flows-flowjax python validation/diagnostics/quick_sense_check.py
+  micromamba run -n frugal-flows-flowjax python validation/diagnostics/quick_sense_check.py \
+      --models gaussian,flexible_continuous --generator gaussian --n 2000 --epochs 400
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import jax
+
+jax.config.update("jax_enable_x64", True)  # must precede any jnp array creation
+
+import jax.numpy as jnp  # noqa: E402
+import jax.random as jr  # noqa: E402
+
+# Make the causl generators + frugal_flows importable regardless of cwd.
+_VALIDATION_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _VALIDATION_DIR not in sys.path:
+    sys.path.insert(0, _VALIDATION_DIR)
+
+import data_processing_and_simulations.causl_sim_data_generation as causl_py  # noqa: E402
+from frugal_flows.causal_flows import train_frugal_flow  # noqa: E402
+
+GENERATORS = {
+    "gaussian": causl_py.generate_gaussian_samples,
+    "mixed": causl_py.generate_mixed_samples,
+}
+
+
+def base_hyperparams(epochs: int) -> dict:
+    return dict(
+        RQS_knots=8,
+        nn_depth=4,
+        nn_width=50,
+        flow_layers=4,
+        learning_rate=5e-3,
+        max_epochs=epochs,
+        max_patience=max(20, epochs // 10),
+        batch_size=256,
+        show_progress=False,
+    )
+
+
+def model_args(causal_model: str, cond_dim: int) -> dict:
+    if causal_model == "gaussian":
+        return {"ate": jnp.zeros(cond_dim), "scale": 1.0, "const": 0.0}
+    if causal_model in ("flexible_continuous", "location_translation"):
+        return {"nn_depth": 4, "nn_width": 50, "RQS_knots": 8, "flow_layers": 4}
+    raise ValueError(f"Unsupported causal_model for sense check: {causal_model}")
+
+
+def final_val_loss(losses) -> float:
+    if isinstance(losses, dict):
+        seq = losses.get("val") or losses.get("train") or next(iter(losses.values()))
+    else:
+        seq = losses
+    return float(seq[-1])
+
+
+def fit_model(key, Y, u_z, X, causal_model, epochs):
+    cond_dim = X.shape[1]
+    ff, losses = train_frugal_flow(
+        key, Y, u_z, condition=X,
+        causal_model=causal_model,
+        causal_model_args=model_args(causal_model, cond_dim),
+        **base_hyperparams(epochs),
+    )
+    return ff, final_val_loss(losses)
+
+
+def intervene_moments(key, ff, cond_dim, n_mc):
+    """Estimate p(Y|do(T=t)) and the ATE by sampling the full flow at fixed T, dim 0.
+
+    Common random numbers: the SAME base draw (same `key`) is pushed through both
+    interventions, so we get PAIRED outcomes (Q_1(u), Q_0(u)) sharing the latent u.
+    ATE = mean of per-draw differences tau(u)=Q_1(u)-Q_0(u). For the mean this equals
+    difference-of-means, but with the MC noise cancelled. std(tau) is the quantile-
+    effect heterogeneity: ~0 for a pure location shift (gaussian/location), >0 for a
+    treatment-conditioned spline. Pairing assumes a shared-rank counterfactual coupling.
+    """
+    s0 = ff.sample(key, condition=jnp.zeros((n_mc, cond_dim)))
+    s1 = ff.sample(key, condition=jnp.ones((n_mc, cond_dim)))
+    y0, y1 = s0[:, 0], s1[:, 0]
+    tau = y1 - y0  # paired per-draw treatment effect tau(u)
+    return {
+        "mean0": float(jnp.mean(y0)), "mean1": float(jnp.mean(y1)),
+        "var0": float(jnp.var(y0)), "var1": float(jnp.var(y1)),
+        "ate": float(jnp.mean(tau)),
+        "tau_sd": float(jnp.std(tau)),  # effect heterogeneity across quantiles
+        "anynan": bool(jnp.any(jnp.isnan(y0)) | jnp.any(jnp.isnan(y1))),
+    }
+
+
+def run_one(key, causal_model, Y, u_z, X, args, true, hard):
+    ff, val_loss = fit_model(jr.fold_in(key, 1), Y, u_z, X, causal_model, args.epochs)
+    m = intervene_moments(jr.fold_in(key, 2), ff, X.shape[1], args.n_mc)
+
+    # --- always-hard SMOKE checks (cheap, scale-independent) ---
+    finite_loss = bool(jnp.isfinite(jnp.array(val_loss)).item())
+    no_nan = not m["anynan"]
+    vars_ok = all(v > 0 and jnp.isfinite(jnp.array(v)).item() for v in (m["var0"], m["var1"]))
+    # interventional effect points the right way (or true ATE ~0 -> skip sign)
+    ate = m["ate"]
+    sign_ok = (abs(true["ate"]) < 1e-8) or (ate * true["ate"] > 0)
+    t_smoke = finite_loss and no_nan and vars_ok and sign_ok
+
+    # --- recovery metrics: HARD only with --full, else informational ---
+    ate_relerr = abs(ate - true["ate"]) / max(abs(true["ate"]), 1e-8)
+    moment_err = max(
+        abs(m["mean0"] - true["const"]),
+        abs(m["mean1"] - (true["const"] + true["ate"])),
+    )
+    var_err = max(abs(m["var0"] - true["phi"]), abs(m["var1"] - true["phi"]))
+    t_ate = ate_relerr < args.tol
+    t_mom = (moment_err < args.moment_tol) and (var_err < args.var_tol)
+
+    passed = (t_smoke and t_ate and t_mom) if hard else t_smoke
+    return {
+        "model": causal_model, "val_loss": val_loss,
+        "ate": ate, "ate_relerr": ate_relerr, "tau_sd": m["tau_sd"],
+        "mean0": m["mean0"], "mean1": m["mean1"], "var0": m["var0"], "var1": m["var1"],
+        "moment_err": moment_err, "var_err": var_err,
+        "t_smoke": t_smoke, "t_ate": t_ate, "t_mom": t_mom, "pass": passed,
+    }
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--models", default="gaussian,flexible_continuous",
+                   help="comma-separated causal_model names")
+    p.add_argument("--generator", default="gaussian", choices=list(GENERATORS))
+    p.add_argument("--full", action="store_true",
+                   help="recovery tier: large n + HARD pass/fail on absolute ATE/moments "
+                        "(default is fast smoke tier: ATE shown but not gated)")
+    p.add_argument("--n", type=int, default=None,
+                   help="training sample size (default 2000 smoke / 20000 --full)")
+    p.add_argument("--epochs", type=int, default=None,
+                   help="max epochs (default 400 smoke / 1500 --full; early-stops)")
+    p.add_argument("--n-mc", type=int, default=20000, help="MC samples for readout")
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--ate", type=float, default=1.0, help="true causl ATE (causal_params[1])")
+    p.add_argument("--const", type=float, default=0.0, help="true causl intercept (causal_params[0])")
+    p.add_argument("--phi", type=float, default=1.0, help="true causl outcome dispersion (Var)")
+    p.add_argument("--tol", type=float, default=0.15, help="relative tol for ATE check (--full)")
+    p.add_argument("--moment-tol", type=float, default=0.3, help="abs tol for interventional means (--full)")
+    p.add_argument("--var-tol", type=float, default=0.5, help="abs tol for interventional variances (--full)")
+    args = p.parse_args()
+
+    # tier defaults
+    if args.n is None:
+        args.n = 20000 if args.full else 2000
+    if args.epochs is None:
+        args.epochs = 1500 if args.full else 400
+
+    models = [m.strip() for m in args.models.split(",") if m.strip()]
+    true = {"ate": args.ate, "const": args.const, "phi": args.phi}
+
+    tier = "FULL (recovery: hard ATE/moment pass-fail)" if args.full \
+        else "SMOKE (fast: runs+NaN+sane-moments gated; ATE informational)"
+    print(f"tier={tier}")
+    print(f"generator={args.generator}  n={args.n}  epochs={args.epochs}  seed={args.seed}")
+    print(f"true: ATE={args.ate}  const={args.const}  phi(Var)={args.phi}\n")
+
+    # one causl dataset, shared across models (apples-to-apples)
+    data = GENERATORS[args.generator](args.n, causal_params=[args.const, args.ate], seed=args.seed)
+    X, Y, Z_disc, Z_cont = data["X"], data["Y"], data["Z_disc"], data["Z_cont"]
+    uz = causl_py.generate_uz_samples(Z_disc, Z_cont, False, args.seed, base_hyperparams(args.epochs))
+    u_z = uz["uz_samples"]
+    print(f"data: X{tuple(X.shape)} Y{tuple(Y.shape)} u_z{tuple(u_z.shape)}  treated_frac={float(X.mean()):.3f}\n")
+
+    key = jr.key(args.seed)
+    rows = [run_one(jr.fold_in(key, i), m, Y, u_z, X, args, true, hard=args.full)
+            for i, m in enumerate(models)]
+
+    # report. In SMOKE tier ate/mom are informational (parenthesised); only smoke gates.
+    def mark(ok):
+        return "OK" if ok else "X"
+
+    hdr = (f"{'model':<22}{'ATE':>8}{'relerr':>9}{'tau_sd':>8}{'E[Y|0]':>9}{'E[Y|1]':>9}{'Var0':>7}{'Var1':>7}"
+           f"  smoke {'ate/mom' if args.full else '(ate/mom info)'}  verdict")
+    print(hdr)
+    print("-" * len(hdr))
+    for r in rows:
+        am = f"{mark(r['t_ate'])}/{mark(r['t_mom'])}"
+        am = am if args.full else f"({am})"
+        verdict = "PASS" if r["pass"] else "FAIL"
+        print(f"{r['model']:<22}{r['ate']:>8.3f}{r['ate_relerr']:>8.1%}{r['tau_sd']:>8.3f}{r['mean0']:>9.3f}"
+              f"{r['mean1']:>9.3f}{r['var0']:>7.2f}{r['var1']:>7.2f}  {mark(r['t_smoke']):>5} {am:>11}  {verdict}")
+    print()
+    overall = all(r["pass"] for r in rows)
+    if args.full:
+        print(f"OVERALL: {'PASS' if overall else 'FAIL'}  "
+              f"(gated: smoke + ATE rel<{args.tol} + mean abs<{args.moment_tol} + var abs<{args.var_tol})")
+    else:
+        print(f"OVERALL: {'PASS' if overall else 'FAIL'}  (gated: smoke only — runs/NaN/sane+ordered moments)")
+        print("note: absolute ATE recovery is NOT gated in smoke tier (needs ~20k samples). "
+              "Run with --full for a hard recovery check.")
+    sys.exit(0 if overall else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/diagnostics/rank_histogram.py
+++ b/validation/diagnostics/rank_histogram.py
@@ -1,0 +1,125 @@
+"""Histogram of the ranks after fitting the frugal flow (calibration / Rosenblatt check).
+
+Two sets of "ranks":
+  INPUT u_z      -- the retained stage-1 marginal ranks (empirical CDF of Z, the
+                    `use_marginal_flow=False` default). Uniform ~by construction.
+  ROSENBLATT     -- push the fitted data (Y, u_z) BACKWARD through the trained flow
+                    to its base, `ff.bijection.inverse(data, condition=X)`. The base
+                    is independent Uniform(-1,1); rescaled to (0,1) these are the
+                    "iid Rosenblatt ranks". If the margin+copula fit, every component
+                    is ~Uniform. Deviations = miscalibration (margin or copula misfit).
+
+Fits the SPLINE arm (`flexible_continuous`) on a gaussian-outcome causl dataset.
+
+Usage (from validation/):
+  micromamba run -n frugal-flows-flowjax python -m diagnostics.rank_histogram \
+      --n 2000 --arm flexible_continuous
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp  # noqa: E402
+import jax.random as jr  # noqa: E402
+import numpy as np  # noqa: E402
+
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+_VALIDATION_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _VALIDATION_DIR not in sys.path:
+    sys.path.insert(0, _VALIDATION_DIR)
+
+import data_processing_and_simulations.causl_sim_data_generation as causl_py  # noqa: E402
+from frugal_flows.causal_flows import train_frugal_flow  # noqa: E402
+from diagnostics.outcome_families import FAMILIES  # noqa: E402
+from diagnostics.quick_sense_check import base_hyperparams, model_args  # noqa: E402
+
+
+def ks_uniform(u):
+    """KS distance of samples u in [0,1] from Uniform(0,1)."""
+    u = np.sort(np.asarray(u))
+    n = len(u)
+    cdf = np.arange(1, n + 1) / n
+    return float(np.max(np.abs(cdf - u)))
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--arm", default="flexible_continuous")
+    p.add_argument("--family", default="gaussian")
+    p.add_argument("--n", type=int, default=2000)
+    p.add_argument("--epochs", type=int, default=600)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--const", type=float, default=0.0)
+    p.add_argument("--ate", type=float, default=1.0)
+    args = p.parse_args()
+
+    fam = FAMILIES[args.family]
+    data = fam.generate(args.n, causal_params=[args.const, args.ate], seed=args.seed)
+    X, Y, Z_disc, Z_cont = data["X"], data["Y"], data["Z_disc"], data["Z_cont"]
+    uz = causl_py.generate_uz_samples(Z_disc, Z_cont, False, args.seed, base_hyperparams(args.epochs))
+    u_z = uz["uz_samples"]
+    k_z = u_z.shape[1]
+    print(f"fitting {args.arm} on {args.family}: X{tuple(X.shape)} Y{tuple(Y.shape)} u_z{tuple(u_z.shape)}")
+
+    key = jr.key(1000 * args.seed + 1)
+    ff, _ = train_frugal_flow(
+        jr.fold_in(key, 1), Y, u_z, condition=X,
+        causal_model=args.arm, causal_model_args=model_args(args.arm, X.shape[1]),
+        **base_hyperparams(args.epochs),
+    )
+
+    # ---- Rosenblatt ranks: push fitted data (Y,u_z) backward to the base ----
+    data_full = jnp.hstack([Y, u_z])  # dim 0 = outcome, dims 1..k = confounder ranks
+    # base is _StandardUniform on (0,1); inverse maps data -> base directly (no rescale)
+    ros = np.asarray(jax.vmap(ff.bijection.inverse, in_axes=(0, 0))(data_full, X))
+    u_z_np = np.asarray(u_z)
+
+    ros_y = ros[:, 0]                  # outcome Rosenblatt rank
+    ros_z = ros[:, 1:].ravel()         # confounder Rosenblatt ranks (pooled)
+    finite = np.isfinite(ros).all(axis=1)
+    print(f"finite Rosenblatt rows: {finite.sum()}/{len(finite)}")
+    print(f"KS-from-uniform: input u_z={ks_uniform(u_z_np.ravel()):.4f}  "
+          f"outcome Rosenblatt={ks_uniform(ros_y[np.isfinite(ros_y)]):.4f}  "
+          f"confounder Rosenblatt={ks_uniform(ros_z[np.isfinite(ros_z)]):.4f}")
+
+    # ---- figure ----
+    fig, axes = plt.subplots(2, 2, figsize=(12, 9))
+    bins = np.linspace(0, 1, 31)
+
+    def _hist(ax, vals, title, color):
+        vals = np.asarray(vals); vals = vals[np.isfinite(vals)]
+        ax.hist(vals, bins=bins, density=True, color=color, alpha=0.8, edgecolor="white")
+        ax.axhline(1.0, color="black", ls="--", lw=1.6, label="Uniform(0,1)")
+        ax.set_ylim(0, 2.2); ax.set_xlabel("rank"); ax.set_ylabel("density")
+        ax.set_title(f"{title}\nKS={ks_uniform(vals):.3f}", fontsize=12)
+        ax.legend(fontsize=9)
+
+    _hist(axes[0, 0], u_z_np.ravel(), "INPUT u_z ranks (retained stage-1 ECDF, all Z dims)", "#7f7f7f")
+    _hist(axes[0, 1], ros_y, "OUTCOME Rosenblatt rank (dim 0, after fit)", "#1f77b4")
+    _hist(axes[1, 0], ros_z, "CONFOUNDER Rosenblatt ranks (dims 1..k, after fit)", "#2ca02c")
+    _hist(axes[1, 1], ros.ravel(), "ALL Rosenblatt ranks pooled (after fit)", "#9467bd")
+
+    fig.suptitle(f"Ranks after fitting the {args.arm} frugal flow ({args.family} outcome, n={args.n})\n"
+                 "flat at density 1 => calibrated (iid Rosenblatt ranks ~ Uniform)", fontsize=14)
+    fig.tight_layout(rect=[0, 0, 1, 0.95])
+    out = os.path.join(os.path.dirname(os.path.abspath(__file__)), "outputs",
+                       f"rank_hist_{args.arm}_{args.family}_n{args.n}.png")
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+    fig.savefig(out, dpi=120)
+    plt.close(fig)
+    print(f"figure: {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/diagnostics/run_diagnostics.py
+++ b/validation/diagnostics/run_diagnostics.py
@@ -1,0 +1,85 @@
+"""Run all three identification diagnostics for one generator + causal config.
+
+Convenience orchestrator: fits/draws once per diagnostic and writes every CSV and
+PDF into ``validation/diagnostics/outputs/``. Each diagnostic is also runnable on
+its own (``python -m diagnostics.d1_ate_recovery`` etc.) — this just chains them
+with a shared config so you get the full picture in one command.
+
+Run (from validation/):
+    micromamba run -n frugal-flows-flowjax python -m diagnostics.run_diagnostics --smoke
+    micromamba run -n frugal-flows-flowjax python -m diagnostics.run_diagnostics \
+        --generator mixed --const 1 --ate 1 --n-samples 20000 --n-iter 25
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import numpy as np
+
+from . import d1_ate_recovery as d1
+from . import d2_margin_shape as d2
+from . import d3_moment_match as d3
+from ._harness import DEFAULT_HYPERPARAMS, SMOKE_HYPERPARAMS, fit_once, outputs_dir, true_params_from_causal_params
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--generator", default="mixed", choices=["gaussian", "mixed", "discrete", "many_discrete"]
+    )
+    parser.add_argument("--const", type=float, default=1.0, help="true const (causal_params[0])")
+    parser.add_argument("--ate", type=float, default=1.0, help="true ate (causal_params[1])")
+    parser.add_argument("--n-samples", type=int, default=20000)
+    parser.add_argument("--n-iter", type=int, default=25, help="seeds for d1 recovery")
+    parser.add_argument("--ref-n", type=int, default=100000, help="d3 causl reference size")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--smoke", action="store_true", help="fast feedback config across all three")
+    parser.add_argument("--outdir", default=None)
+    args = parser.parse_args()
+
+    causal_params = [args.const, args.ate]
+    true_params = true_params_from_causal_params(causal_params)
+    outdir = args.outdir or outputs_dir()
+    os.makedirs(outdir, exist_ok=True)
+
+    if args.smoke:
+        hyperparams = dict(SMOKE_HYPERPARAMS)
+        n_samples = min(args.n_samples, 2000) if args.n_samples == 20000 else args.n_samples
+        n_iter = min(args.n_iter, 3) if args.n_iter == 25 else args.n_iter
+        ref_n = min(args.ref_n, 20000) if args.ref_n == 100000 else args.ref_n
+    else:
+        hyperparams = dict(DEFAULT_HYPERPARAMS)
+        n_samples, n_iter, ref_n = args.n_samples, args.n_iter, args.ref_n
+
+    print(f"\n{'=' * 70}\n[run] generator={args.generator}  truth={true_params}\n"
+          f"      n_samples={n_samples}  n_iter={n_iter}  ref_n={ref_n}\n{'=' * 70}")
+
+    # --- d1: ATE recovery (n_iter fits) ---
+    print("\n>>> d1 ATE recovery")
+    results = d1.run_recovery(args.generator, causal_params, n_samples, n_iter, args.seed, hyperparams)
+    results.to_csv(os.path.join(outdir, f"d1_{args.generator}_recovery.csv"), index=False)
+    print(d1.summarise(results, true_params).to_string(float_format=lambda v: f"{v:+.4f}"))
+    d1.plot_recovery(results, true_params, os.path.join(outdir, f"d1_{args.generator}_recovery.pdf"))
+
+    # --- d2: margin shape (one fit; reuse seed 0) ---
+    print("\n>>> d2 margin shape")
+    res = fit_once(args.generator, causal_params, n_samples, seed=args.seed, hyperparams=hyperparams)
+    print(f"    recovered={res.recovered}")
+    for k, v in d2.sense_checks(res.recovered, np.linspace(1e-3, 1 - 1e-3, 400)).items():
+        print(f"    {k}: {v}")
+    d2.plot_margin(res.recovered, res.true_params, os.path.join(outdir, f"d2_{args.generator}_margin.pdf"))
+
+    # --- d3: moment match (no fit) ---
+    print("\n>>> d3 moment match")
+    table, reference, sample = d3.run_moment_match(args.generator, causal_params, n_samples, ref_n, args.seed)
+    table.to_csv(os.path.join(outdir, f"d3_{args.generator}_moments.csv"))
+    print(table.to_string(float_format=lambda v: f"{v:+.4f}"))
+    d3.plot_moments(reference, sample, os.path.join(outdir, f"d3_{args.generator}_moments.pdf"), ref_n, n_samples)
+
+    print(f"\n[run] all diagnostics written to {outdir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Moves the validation sense-checks out of the notebooks into a runnable script suite at `validation/diagnostics/`, so parameter-identification checks can be run (and re-run) without notebook state:

- **d1/d2/d3 + run_diagnostics** — identification harness: ATE/const/scale recovery over seeds, interventional margin shape (gap ≡ ATE check), causl moment match.
- **quick_sense_check** — two-tier (fast smoke / slow full) end-to-end causl sense check with a model-agnostic **paired common-random-numbers ATE readout** (same base draw through do(0)/do(1); works for both `gaussian` and `flexible_continuous` arms, where the parameter-extraction readout is gaussian-only).
- **outcome_families** — causl ground-truth generators parameterised by outcome family (gaussian / gamma-log-link) with **analytic true ATE and τ(u)**, and a continuous confounding-strength knob `confound_beta` (β=0 randomised … β=1 original DGP).
- **ate_extraction_suite** — `intervene()` + `tau_curve()` readouts, validated three independent ways (analytic field == full-flow sampling == direct margin inversion).
- **rank_histogram** — Rosenblatt-rank calibration check (note: the frugal-flow base is uniform on (0,1), no rescale needed).
- **ate_sweep** — ATE-recovery-vs-n benchmark across causal-model arms.

## Usage
From `validation/`, in the R-causl env: `python -m diagnostics.run_diagnostics --smoke`, `python -m diagnostics.quick_sense_check`, etc. See `diagnostics/README.md`.

## Test plan
- Smoke tier of the full battery run end-to-end on the gamma + gaussian families (d1 bias ≤ 0.034; d2 frugality gap ~1e-16; d3 reproduces Gamma mean e, var 7.39).
- `outcome_families` analytic truths cross-checked against large-n Monte Carlo.

Companion PR #(follow-up) builds the spline-vs-additive causal-margin study on top of this harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)